### PR TITLE
Get Reference childNodes of any node in the parse tree

### DIFF
--- a/src/XLParser/ExcelFormulaParser.cs
+++ b/src/XLParser/ExcelFormulaParser.cs
@@ -440,6 +440,17 @@ namespace XLParser
         }
 
         /// <summary>
+        /// Get all child nodes that are references and aren't part of another reference expression
+        /// </summary>
+        public static IEnumerable<ParseTreeNode> GetReferenceNodes(this ParseTreeNode input)
+        {
+            return input.AllNodesConditional(node => node.Is(GrammarNames.Reference))
+                .Where(node => node.Is(GrammarNames.Reference))
+                .Select(node => node.SkipToRelevant())
+                ;
+        }
+
+        /// <summary>
         /// Go to the first "relevant" child node, i.e. skips wrapper nodes
         /// </summary>
         /// <remarks>

--- a/src/XLParser/FormulaAnalyzer.cs
+++ b/src/XLParser/FormulaAnalyzer.cs
@@ -52,10 +52,7 @@ namespace XLParser
         /// </summary>
         public IEnumerable<ParseTreeNode> References()
         {
-            return Root.AllNodesConditional(node => node.Is(GrammarNames.Reference))
-                .Where(node => node.Is(GrammarNames.Reference))
-                .Select(node => node.SkipToRelevant())
-                ;
+            return Root.GetReferenceNodes();
         }
 
         public IEnumerable<string> Functions()


### PR DESCRIPTION
The FormulaAnalyzer.References() method returns all reference nodes that are not part of another reference expression. For formula `=INDEX(1,OR(D15>89.5,D27>89.5),1,0)`, it returns only one Reference node, corresponding to the `INDEX` RefFunctionCall.

If we want to obtain the reference nodes for `D15` and `D27`, that are grandchildren of the `INDEX` node, we need to start the search at this node instead of the root. This pr adds method ParseTreeNode.GetReferenceNodes() for this reason.