### PR TITLE
Added special characters in structured references

### DIFF
--- a/src/XLParser.Tests/data/testformulas/structured_references.txt
+++ b/src/XLParser.Tests/data/testformulas/structured_references.txt
@@ -26,3 +26,4 @@
 =DeptSales[ [SalesPers]:[Region] ]
 =DeptSales[[#Headers], [#Data], [ComPct]]
 =DeptSales[@Column]
+=Tabel25[[#This Row],[I/HV]]

--- a/src/XLParser/ExcelFormulaGrammar.cs
+++ b/src/XLParser/ExcelFormulaGrammar.cs
@@ -150,7 +150,7 @@ namespace XLParser
         { Priority = TerminalPriority.FileNameNumericToken };
 
         private const string fileNameForbiddenCharacter = @"<>:""/\|?*";
-        private const string fileNameRegex = @"\[[^" + fileNameForbiddenCharacter + @"\[\]]+\]";
+        private const string fileNameRegex = @"\[[^\[\]]+\]";
         public Terminal EnclosedInBracketsToken { get; } = new RegexBasedTerminal(GrammarNames.TokenEnclosedInBrackets, fileNameRegex)
         { Priority = TerminalPriority.FileName };
 


### PR DESCRIPTION
Characters ```<>:"/\|?*``` were not allowed in the column specifiers of structured references. This removes this limitation and adds test.
Fixes #34.