### PR TITLE
Correct NamedRangeCombinationToken

### DIFF
--- a/src/XLParser.Tests/ParserTests.cs
+++ b/src/XLParser.Tests/ParserTests.cs
@@ -197,7 +197,11 @@ namespace XLParser.Tests
         [TestMethod]
         public void CellReference()
         {
-            test("+BSO48");
+            var cells = new[] {"A1", "Z9", "AB10", "ABC999", "BSO48"};
+            foreach (var cell in cells)
+            {
+                test(cell, tree => tree.AllNodes(GrammarNames.Cell).Select(ExcelFormulaParser.Print).FirstOrDefault() == cell);
+            }
         }
 
 

--- a/src/XLParser.Tests/ParserTests.cs
+++ b/src/XLParser.Tests/ParserTests.cs
@@ -733,6 +733,18 @@ namespace XLParser.Tests
             test(new [] { "VLOOKUP(' '!G3,' '!B4:F99,5)", "VLOOKUP('\t'!G3,'\t'!B4:F99,5)", "VLOOKUP('   '!G3,'   '!B4:F99,5)" },
                 // Make sure they all return a single space as sheet name
                 tree => tree.AllNodes(GrammarNames.Prefix).All(node => node.GetPrefixInfo().Sheet == " "));
-        } 
+        }
+
+        [TestMethod]
+        public void TestNamedRangeCombination()
+        {
+            // See [Issue 46](https://github.com/spreadsheetlab/XLParser/issues/46)
+            // Names which start with non-name words, e.g. 
+            var names = new[] {"A1ABC", "A1A1", "A2.PART_NUM", "A2?PART_NUM", "TRUEFOO", "FALSEFOO"};
+            foreach (var name in names)
+            {
+                test(name, tree => tree.AllNodes(GrammarNames.NamedRange).Select(ExcelFormulaParser.Print).Contains(name));
+            }
+        }
     }
 }

--- a/src/XLParser.Tests/ParserTests.cs
+++ b/src/XLParser.Tests/ParserTests.cs
@@ -744,7 +744,7 @@ namespace XLParser.Tests
         {
             // See [Issue 46](https://github.com/spreadsheetlab/XLParser/issues/46)
             // Names which start with non-name words, e.g. 
-            var names = new[] {"A1ABC", "A1A1", "A2.PART_NUM", "A2?PART_NUM", "TRUEFOO", "FALSEFOO"};
+            var names = new[] {"A1ABC", "A1A1", "A2.PART_NUM", "A2?PART_NUM", "TRUEFOO", "FALSEFOO", "TRUEMODEL" };
             foreach (var name in names)
             {
                 test(name, tree => tree.AllNodes(GrammarNames.NamedRange).Select(ExcelFormulaParser.Print).Contains(name));

--- a/src/XLParser/ExcelFormulaGrammar.cs
+++ b/src/XLParser/ExcelFormulaGrammar.cs
@@ -114,9 +114,10 @@ namespace XLParser
         // TODO: Add all function names here
         
         private const string NameInvalidWordsRegex =
-              "((TRUE | FALSE)" + NameValidCharacterRegex + "+)"
+              "((TRUE|FALSE)" + NameValidCharacterRegex + "+)"
             // \w is equivalent to [\p{Ll}\p{Lu}\p{Lt}\p{Lo}\p{Lm}\p{Nd}\p{Pc}], we want the decimal left out here because otherwise "A11" would be a combination token
-            + "|(" + CellTokenRegex + @"[\p{Ll}\p{Lu}\p{Lt}\p{Lo}\p{Lm}\p{Pc}\\_\.\?])" + NameValidCharacterRegex + "*";
+            + "|(" + CellTokenRegex + @"[\p{Ll}\p{Lu}\p{Lt}\p{Lo}\p{Lm}\p{Pc}\\_\.\?]" + NameValidCharacterRegex + "*)"
+            ;
 
         // To prevent e.g. "A1A1" being parsed as 2 celltokens
         public Terminal NamedRangeCombinationToken { get; } = new RegexBasedTerminal(GrammarNames.TokenNamedRangeCombination, NameInvalidWordsRegex + NameValidCharacterRegex + "+")

--- a/src/XLParser/ExcelFormulaGrammar.cs
+++ b/src/XLParser/ExcelFormulaGrammar.cs
@@ -103,12 +103,18 @@ namespace XLParser
         { Priority = TerminalPriority.CellToken };
 
         // Start with a letter or underscore, continue with word character (letters, numbers and underscore), dot or question mark 
-        private const string NamedRangeRegex = @"[\p{L}\\_][\w\\_\.\?]*";
-        public Terminal NameToken { get; } = new RegexBasedTerminal(GrammarNames.TokenName, NamedRangeRegex)
+        private const string NameStartCharRegex = @"[\p{L}\\_]";
+        private const string NameValidCharacterRegex = @"[\w\\_\.\?]*";
+        public Terminal NameToken { get; } = new RegexBasedTerminal(GrammarNames.TokenName, NameStartCharRegex + NameValidCharacterRegex)
         { Priority = TerminalPriority.Name };
 
+        // Words that are valid names, but are dissalowed by Excel. E.g. "A1" is a valid name, but it is not because it is also a cell reference.
+        // If we ever parse R1C1 references, make sure to include them here
+        // TODO: Add all function names here
+        private const string NameInvalidWordsRegex = "(TRUE|FALSE|" + CellTokenRegex + ")";
+
         // To prevent e.g. "A1A1" being parsed as 2 celltokens
-        public Terminal NamedRangeCombinationToken { get; } = new RegexBasedTerminal(GrammarNames.TokenNamedRangeCombination, "(TRUE|FALSE|" + CellTokenRegex + ")" + NamedRangeRegex)
+        public Terminal NamedRangeCombinationToken { get; } = new RegexBasedTerminal(GrammarNames.TokenNamedRangeCombination, NameInvalidWordsRegex + NameValidCharacterRegex)
         { Priority = TerminalPriority.NamedRangeCombination };
 
         public Terminal ReservedNameToken = new RegexBasedTerminal(GrammarNames.TokenReservedName, @"_xlnm\.[a-zA-Z_]+")


### PR DESCRIPTION
Corrects characters allowed following the start word in NamedRangeCombinationToken

Fixes #46