### PR TITLE
Fix for UDF names consisting only of "R" or "C".

### DIFF
--- a/src/XLParser.Tests/ParserTests.cs
+++ b/src/XLParser.Tests/ParserTests.cs
@@ -786,5 +786,18 @@ namespace XLParser.Tests
 
             Assert.ThrowsException<ArgumentException>(() => ExcelFormulaParser.ParseToTree("A↑()"));
         }
+
+        [TestMethod]
+        public void DoNotParseUdfNamesConsistingOnlyOfROrC()
+        {
+            // See [#56](https://github.com/spreadsheetlab/XLParser/issues/56)
+            // UDF function names consisting of a single character "R" or "C" must be prefixed by the module name
+            foreach (var disallowed in "RrCc")
+            {
+                Assert.ThrowsException<ArgumentException>(() => ExcelFormulaParser.ParseToTree($"{disallowed}()"));
+            }
+
+            Test("Module1.R()", "N()", "T()", "Ñ()");
+        }
     }
 }

--- a/src/XLParser/ExcelFormulaGrammar.cs
+++ b/src/XLParser/ExcelFormulaGrammar.cs
@@ -75,11 +75,15 @@ namespace XLParser
         #endregion
 
         #region Functions
-
         private const string SpecialUdfChars = "¡¢£¤¥¦§¨©«¬­®¯°±²³´¶·¸¹»¼½¾¿×÷"; // Non-word characters from ISO 8859-1 that are allowed in VBA identifiers
+        private const string AllUdfChars = SpecialUdfChars + @"\\.\w";
+        private const string UdfPrefixRegex = @"('[^<>""/\|?*]+\.xla'!|_xll\.)";
 
-        public Terminal UDFToken { get; } = new RegexBasedTerminal(GrammarNames.TokenUDF, $@"('[^<>""/\|?*]+\.xla'!|_xll\.)?[\w{SpecialUdfChars}\\.]+\(")
-        { Priority = TerminalPriority.UDF };
+        // The following regex uses the rather exotic feature Character Class Subtraction
+        // https://docs.microsoft.com/en-us/dotnet/standard/base-types/character-classes-in-regular-expressions#CharacterClassSubtraction
+        private static readonly string UdfTokenRegex = $@"([{AllUdfChars}-[CcRr]]|{UdfPrefixRegex}[{AllUdfChars}]|{UdfPrefixRegex}?[{AllUdfChars}]{{2,1023}})\(";
+
+        public Terminal UDFToken { get; } = new RegexBasedTerminal(GrammarNames.TokenUDF, UdfTokenRegex) {Priority = TerminalPriority.UDF};
 
         public Terminal ExcelRefFunctionToken { get; } = new RegexBasedTerminal(GrammarNames.TokenExcelRefFunction, "(INDEX|OFFSET|INDIRECT)\\(")
         { Priority = TerminalPriority.ExcelRefFunction };


### PR DESCRIPTION
A UDF name consisting only of "R" or "C" is not allowed. These names must be preceded by the module name.

Resolves #56