### PR TITLE
Improve on external file paths

### DIFF
--- a/src/XLParser.Tests/FormulaAnalysisTest.cs
+++ b/src/XLParser.Tests/FormulaAnalysisTest.cs
@@ -314,30 +314,30 @@ namespace XLParser.Tests
         [TestMethod]
         public void ExternalWorkbookSingleCell()
         {
-            List<ParserReference> result = new FormulaAnalyzer(@"'C:\Users\Willem-Jan\Desktop\[Data.xlsx]Sheet1'!$A$1").ParserReferences().ToList();
+            List<ParserReference> result = new FormulaAnalyzer(@"='C:\Users\Test\Desktop\[Book1.xlsx]Sheet1'!$A$1").ParserReferences().ToList();
             Assert.AreEqual(1, result.Count);
             Assert.AreEqual(ReferenceType.Cell, result.First().ReferenceType);
-            Assert.AreEqual("Data.xlsx", result.First().FileName);
+            Assert.AreEqual("Book1.xlsx", result.First().FileName);
             Assert.AreEqual("Sheet1", result.First().Worksheet);
         }
 
         [TestMethod]
         public void ExternalWorkbookCellRange()
         {
-            List<ParserReference> result = new FormulaAnalyzer(@"'C:\Users\Willem-Jan\Desktop\[Data.xlsx]Sheet1'!$A$1:$A$10").ParserReferences().ToList();
+            List<ParserReference> result = new FormulaAnalyzer(@"='C:\Users\Test\Desktop\[Book1.xlsx]Sheet1'!$A$1:$A$10").ParserReferences().ToList();
             Assert.AreEqual(1, result.Count);
             Assert.AreEqual(ReferenceType.CellRange, result.First().ReferenceType);
-            Assert.AreEqual("Data.xlsx", result.First().FileName);
+            Assert.AreEqual("Book1.xlsx", result.First().FileName);
             Assert.AreEqual("Sheet1", result.First().Worksheet);
         }
 
         [TestMethod]
         public void ExternalWorkbookDefinedNameLocalScope()
         {
-            List<ParserReference> result = new FormulaAnalyzer(@"'C:\Users\Willem-Jan\Desktop\[Data.xlsx]Sheet1'!FirstItem").ParserReferences().ToList();
+            List<ParserReference> result = new FormulaAnalyzer(@"='C:\Users\Test\Desktop\[Book1.xlsx]Sheet1'!FirstItem").ParserReferences().ToList();
             Assert.AreEqual(1, result.Count);
             Assert.AreEqual(ReferenceType.UserDefinedName, result.First().ReferenceType);
-            Assert.AreEqual("Data.xlsx", result.First().FileName);
+            Assert.AreEqual("Book1.xlsx", result.First().FileName);
             Assert.AreEqual("Sheet1", result.First().Worksheet);
             Assert.AreEqual("FirstItem", result.First().Name);
         }
@@ -345,56 +345,56 @@ namespace XLParser.Tests
         [TestMethod]
         public void ExternalWorkbookDefinedNameGlobalScope()
         {
-            List<ParserReference> result = new FormulaAnalyzer(@"'C:\Users\Willem-Jan\Desktop\Data.xlsx'!Items").ParserReferences().ToList();
+            List<ParserReference> result = new FormulaAnalyzer(@"='C:\Users\Test\Desktop\Book1.xlsx'!Items").ParserReferences().ToList();
             Assert.AreEqual(1, result.Count);
             Assert.AreEqual(ReferenceType.UserDefinedName, result.First().ReferenceType);
-            Assert.AreEqual("Data.xlsx", result.First().FileName);
+            Assert.AreEqual("Book1.xlsx", result.First().FileName);
             Assert.AreEqual("Items", result.First().Name);
         }
 
         [TestMethod]
         public void MultipleExternalWorkbookSingleCell()
         {
-            List<ParserReference> result = new FormulaAnalyzer(@"=SUM('C:\Users\Willem-Jan\Desktop\[Data.xlsx]Sheet1'!$A$1,'C:\Users\Willem-Jan\Desktop\[Data.xlsx]Sheet1'!$A$2)").ParserReferences().ToList();
+            List<ParserReference> result = new FormulaAnalyzer(@"=SUM('C:\Users\Test\Desktop\[Book1.xlsx]Sheet1'!$A$1,'C:\Users\Test\Desktop\[Book1.xlsx]Sheet1'!$A$2)").ParserReferences().ToList();
             Assert.AreEqual(2, result.Count);
             
             Assert.AreEqual(ReferenceType.Cell, result[0].ReferenceType);
-            Assert.AreEqual("Data.xlsx", result[0].FileName);
+            Assert.AreEqual("Book1.xlsx", result[0].FileName);
             Assert.AreEqual("Sheet1", result[0].Worksheet);
 
             Assert.AreEqual(ReferenceType.Cell, result[1].ReferenceType);
-            Assert.AreEqual("Data.xlsx", result[1].FileName);
+            Assert.AreEqual("Book1.xlsx", result[1].FileName);
             Assert.AreEqual("Sheet1", result[1].Worksheet);
         }
 
         [TestMethod]
         public void MultipleExternalWorkbookCellRange()
         {
-            List<ParserReference> result = new FormulaAnalyzer(@"=SUM('C:\Users\Willem-Jan\Desktop\[Data.xlsx]Sheet1'!$A$1:$A$10,'C:\Users\Willem-Jan\Desktop\[Data.xlsx]Sheet1'!$A$11:$A$20)").ParserReferences().ToList();
+            List<ParserReference> result = new FormulaAnalyzer(@"=SUM('C:\Users\Test\Desktop\[Book1.xlsx]Sheet1'!$A$1:$A$10,'C:\Users\Test\Desktop\[Book1.xlsx]Sheet1'!$A$11:$A$20)").ParserReferences().ToList();
             Assert.AreEqual(2, result.Count);
             
             Assert.AreEqual(ReferenceType.CellRange, result[0].ReferenceType);
-            Assert.AreEqual("Data.xlsx", result[0].FileName);
+            Assert.AreEqual("Book1.xlsx", result[0].FileName);
             Assert.AreEqual("Sheet1", result[0].Worksheet);
 
             Assert.AreEqual(ReferenceType.CellRange, result[1].ReferenceType);
-            Assert.AreEqual("Data.xlsx", result[1].FileName);
+            Assert.AreEqual("Book1.xlsx", result[1].FileName);
             Assert.AreEqual("Sheet1", result[1].Worksheet);
         }
 
         [TestMethod]
         public void MultipleExternalWorkbookDefinedNameLocalScope()
         {
-            List<ParserReference> result = new FormulaAnalyzer(@"=SUM('C:\Users\Willem-Jan\Desktop\[Data.xlsx]Sheet1'!FirstItem,'C:\Users\Willem-Jan\Desktop\[Data.xlsx]Sheet1'!SecondItem)").ParserReferences().ToList();
+            List<ParserReference> result = new FormulaAnalyzer(@"=SUM('C:\Users\Test\Desktop\[Book1.xlsx]Sheet1'!FirstItem,'C:\Users\Test\Desktop\[Book1.xlsx]Sheet1'!SecondItem)").ParserReferences().ToList();
             Assert.AreEqual(2, result.Count);
             
             Assert.AreEqual(ReferenceType.UserDefinedName, result[0].ReferenceType);
-            Assert.AreEqual("Data.xlsx", result[0].FileName);
+            Assert.AreEqual("Book1.xlsx", result[0].FileName);
             Assert.AreEqual("Sheet1", result[0].Worksheet);
             Assert.AreEqual("FirstItem", result[0].Name);
 
             Assert.AreEqual(ReferenceType.UserDefinedName, result[1].ReferenceType);
-            Assert.AreEqual("Data.xlsx", result[1].FileName);
+            Assert.AreEqual("Book1.xlsx", result[1].FileName);
             Assert.AreEqual("Sheet1", result[1].Worksheet);
             Assert.AreEqual("SecondItem", result[1].Name);
         }
@@ -402,15 +402,15 @@ namespace XLParser.Tests
         [TestMethod]
         public void MultipleExternalWorkbookDefinedNameGlobalScope()
         {
-            List<ParserReference> result = new FormulaAnalyzer(@"=SUM('C:\Users\Willem-Jan\Desktop\Data.xlsx'!Items,'C:\Users\Willem-Jan\Desktop\Data.xlsx'!Items2)").ParserReferences().ToList();
+            List<ParserReference> result = new FormulaAnalyzer(@"=SUM('C:\Users\Test\Desktop\Book1.xlsx'!Items,'C:\Users\Test\Desktop\Book1.xlsx'!Items2)").ParserReferences().ToList();
             Assert.AreEqual(2, result.Count);
             
             Assert.AreEqual(ReferenceType.UserDefinedName, result[0].ReferenceType);
-            Assert.AreEqual("Data.xlsx", result[0].FileName);
+            Assert.AreEqual("Book1.xlsx", result[0].FileName);
             Assert.AreEqual("Items", result[0].Name);
 
             Assert.AreEqual(ReferenceType.UserDefinedName, result[1].ReferenceType);
-            Assert.AreEqual("Data.xlsx", result[1].FileName);
+            Assert.AreEqual("Book1.xlsx", result[1].FileName);
             Assert.AreEqual("Items2", result[1].Name);
         }
 

--- a/src/XLParser.Tests/FormulaAnalysisTest.cs
+++ b/src/XLParser.Tests/FormulaAnalysisTest.cs
@@ -312,6 +312,46 @@ namespace XLParser.Tests
         }
 
         [TestMethod]
+        public void ExternalWorkbook()
+        {
+            List<ParserReference> result = new FormulaAnalyzer(@"='C:\Users\Test\Desktop\[Book1.xlsx]Sheet1'!$A$1").ParserReferences().ToList();
+            Assert.AreEqual(1, result.Count);
+            Assert.AreEqual(@"C:\Users\Test\Desktop\", result.First().FilePath);
+            Assert.AreEqual("Book1.xlsx", result.First().FileName);
+            Assert.AreEqual("Sheet1", result.First().Worksheet);
+        }
+
+        [TestMethod]
+        public void ExternalWorkbookNetworkPath()
+        {
+            List<ParserReference> result = new FormulaAnalyzer(@"='\\TEST-01\Folder\[Book1.xlsx]Sheet1'!$A$1").ParserReferences().ToList();
+            Assert.AreEqual(1, result.Count);
+            Assert.AreEqual(@"\\TEST-01\Folder\", result.First().FilePath);
+            Assert.AreEqual("Book1.xlsx", result.First().FileName);
+            Assert.AreEqual("Sheet1", result.First().Worksheet);
+        }
+
+        [TestMethod]
+        public void ExternalWorkbookUrlPath()
+        {
+            List<ParserReference> result = new FormulaAnalyzer(@"='http:\\example.com\test\[Book1.xlsx]Sheet1'!$A$1").ParserReferences().ToList();
+            Assert.AreEqual(1, result.Count);
+            Assert.AreEqual(@"http:\\example.com\test\", result.First().FilePath);
+            Assert.AreEqual("Book1.xlsx", result.First().FileName);
+            Assert.AreEqual("Sheet1", result.First().Worksheet);
+        }
+
+        [TestMethod]
+        public void ExternalWorkbookRelativePath()
+        {
+            List<ParserReference> result = new FormulaAnalyzer(@"='Test\Folder\[Book1.xlsx]Sheet1'!$A$1").ParserReferences().ToList();
+            Assert.AreEqual(1, result.Count);
+            Assert.AreEqual(@"Test\Folder\", result.First().FilePath);
+            Assert.AreEqual("Book1.xlsx", result.First().FileName);
+            Assert.AreEqual("Sheet1", result.First().Worksheet);
+        }
+
+        [TestMethod]
         public void ExternalWorkbookSingleCell()
         {
             List<ParserReference> result = new FormulaAnalyzer(@"='C:\Users\Test\Desktop\[Book1.xlsx]Sheet1'!$A$1").ParserReferences().ToList();

--- a/src/XLParser.Tests/ParserTests.cs
+++ b/src/XLParser.Tests/ParserTests.cs
@@ -722,6 +722,33 @@ namespace XLParser.Tests
         }
 
         [TestMethod]
+        public void ExternalWorkbook()
+        {
+            Test(@"='C:\Users\Test\Desktop\[Book1.xlsx]Sheet1'!$A$1");
+        }
+
+        [TestMethod]
+        public void ExternalWorkbookNetworkPath()
+        {
+            // See [#107](https://github.com/spreadsheetlab/XLParser/issues/107)
+            Test(@"='\\TEST-01\Folder\[Book1.xlsx]Sheet1'!$A$1");
+        }
+
+        [TestMethod]
+        public void ExternalWorkbookUrlPath()
+        {
+            // See [#107](https://github.com/spreadsheetlab/XLParser/issues/108)
+            Test(@"='http:\\example.com\test\[Book1.xlsx]Sheet1'!$A$1");
+        }
+
+        [TestMethod]
+        public void ExternalWorkbookRelativePath()
+        {
+            // See [#107](https://github.com/spreadsheetlab/XLParser/issues/109)
+            Test(@"='Test\Folder\[Book1.xlsx]Sheet1'!$A$1");
+        }
+
+        [TestMethod]
         public void ExternalWorkbookSingleCell()
         {
             Test(@"'C:\Users\Willem-Jan\Desktop\[Data.xlsx]Sheet1'!$A$1");

--- a/src/XLParser.Tests/ParserTests.cs
+++ b/src/XLParser.Tests/ParserTests.cs
@@ -751,50 +751,50 @@ namespace XLParser.Tests
         [TestMethod]
         public void ExternalWorkbookSingleCell()
         {
-            Test(@"'C:\Users\Willem-Jan\Desktop\[Data.xlsx]Sheet1'!$A$1");
+            Test(@"='C:\Users\Test\Desktop\[Book1.xlsx]Sheet1'!$A$1");
         }
 
         [TestMethod]
         public void ExternalWorkbookCellRange()
         {
-            Test(@"'C:\Users\Willem-Jan\Desktop\[Data.xlsx]Sheet1'!$A$1:$A$10");
+            Test(@"='C:\Users\Test\Desktop\[Book1.xlsx]Sheet1'!$A$1:$A$10");
         }
 
         [TestMethod]
         public void ExternalWorkbookDefinedNameLocalScope()
         {
-            Test(@"'C:\Users\Willem-Jan\Desktop\[Data.xlsx]Sheet1'!FirstItem");
+            Test(@"='C:\Users\Test\Desktop\[Book1.xlsx]Sheet1'!FirstItem");
         }
 
         [TestMethod]
         public void ExternalWorkbookDefinedNameGlobalScope()
         {
             // See [#101](https://github.com/spreadsheetlab/XLParser/issues/101)
-            Test(@"'C:\Users\Willem-Jan\Desktop\Data.xlsx'!Items");
+            Test(@"='C:\Users\Test\Desktop\Book1.xlsx'!Items");
         }
 
         [TestMethod]
         public void MultipleExternalWorkbookSingleCell()
         {
-            Test(@"=SUM('C:\Users\Willem-Jan\Desktop\[Data.xlsx]Sheet1'!$A$1,'C:\Users\Willem-Jan\Desktop\[Data.xlsx]Sheet1'!$A$2)");
+            Test(@"=SUM('C:\Users\Test\Desktop\[Book1.xlsx]Sheet1'!$A$1,'C:\Users\Test\Desktop\[Book1.xlsx]Sheet1'!$A$2)");
         }
 
         [TestMethod]
         public void MultipleExternalWorkbookCellRange()
         {
-            Test(@"=SUM('C:\Users\Willem-Jan\Desktop\[Data.xlsx]Sheet1'!$A$1:$A$10,'C:\Users\Willem-Jan\Desktop\[Data.xlsx]Sheet1'!$A$11:$A$20)");
+            Test(@"=SUM('C:\Users\Test\Desktop\[Book1.xlsx]Sheet1'!$A$1:$A$10,'C:\Users\Test\Desktop\[Book1.xlsx]Sheet1'!$A$11:$A$20)");
         }
 
         [TestMethod]
         public void MultipleExternalWorkbookDefinedNameLocalScope()
         {
-            Test(@"=SUM('C:\Users\Willem-Jan\Desktop\[Data.xlsx]Sheet1'!FirstItem,'C:\Users\Willem-Jan\Desktop\[Data.xlsx]Sheet1'!SecondItem)");
+            Test(@"=SUM('C:\Users\Test\Desktop\[Book1.xlsx]Sheet1'!FirstItem,'C:\Users\Test\Desktop\[Book1.xlsx]Sheet1'!SecondItem)");
         }
 
         [TestMethod]
         public void MultipleExternalWorkbookDefinedNameGlobalScope()
         {
-            Test(@"=SUM('C:\Users\Willem-Jan\Desktop\Data.xlsx'!Items,'C:\Users\Willem-Jan\Desktop\Data.xlsx'!Items2)");
+            Test(@"=SUM('C:\Users\Test\Desktop\Book1.xlsx'!Items,'C:\Users\Test\Desktop\Book1.xlsx'!Items2)");
         }
 
         [TestMethod]

--- a/src/XLParser/ExcelFormulaGrammar.cs
+++ b/src/XLParser/ExcelFormulaGrammar.cs
@@ -184,7 +184,7 @@ namespace XLParser
         
         // Source: http://stackoverflow.com/a/6416209/572635
         private const string fileNameForbiddenCharacter = @"<>:""/\|?*";
-        private const string filePathRegex = @"(?:[a-zA-Z]\:|\\\\[\w\.]+\\[\w.$]+)\\(([^" + fileNameForbiddenCharacter + @"\\]| )+\\)*";
+        private const string filePathRegex = @"(?:[a-zA-Z]:|https?:\\|\\?\\?[\w\.-]+\\[\w.$]+)\\(([^" + fileNameForbiddenCharacter + @"\\]| )+\\)*";
         public Terminal FilePathToken { get; } = new RegexBasedTerminal(GrammarNames.TokenFilePath, filePathRegex);
         #endregion
 

--- a/src/XLParser/ExcelFormulaGrammar.cs
+++ b/src/XLParser/ExcelFormulaGrammar.cs
@@ -170,22 +170,22 @@ namespace XLParser
         { Priority = TerminalPriority.MultipleSheetsToken };
 
         private const string fileNameNumericRegex = @"\[[0-9]+\]";
-        public Terminal FileToken = new RegexBasedTerminal(GrammarNames.TokenFileNameNumeric, fileNameNumericRegex)
+        public Terminal FileNameNumericToken = new RegexBasedTerminal(GrammarNames.TokenFileNameNumeric, fileNameNumericRegex)
         { Priority = TerminalPriority.FileNameNumericToken };
         
-        private const string fileNameForbiddenCharacter = @"<>:""/\|?*";
         private const string fileNameInBracketsRegex = @"\[[^\[\]]+\]";
-        public Terminal EnclosedInBracketsToken { get; } = new RegexBasedTerminal(GrammarNames.TokenEnclosedInBrackets, fileNameInBracketsRegex)
+        public Terminal FileNameEnclosedInBracketsToken { get; } = new RegexBasedTerminal(GrammarNames.TokenFileNameEnclosedInBrackets, fileNameInBracketsRegex)
             { Priority = TerminalPriority.FileName };
         
         // Source: https://stackoverflow.com/a/14632579
         private const string fileNameRegex = @"[^\.]+\..{1,4}";
-        public Terminal FileNameWindowsToken { get; } = new RegexBasedTerminal(GrammarNames.TokenFileNameWindows, fileNameRegex)
+        public Terminal FileName { get; } = new RegexBasedTerminal(GrammarNames.TokenFileName, fileNameRegex)
             { Priority = TerminalPriority.FileName };
         
         // Source: http://stackoverflow.com/a/6416209/572635
+        private const string fileNameForbiddenCharacter = @"<>:""/\|?*";
         private const string filePathRegex = @"(?:[a-zA-Z]\:|\\\\[\w\.]+\\[\w.$]+)\\(([^" + fileNameForbiddenCharacter + @"\\]| )+\\)*";
-        public Terminal FilePathWindowsToken { get; } = new RegexBasedTerminal(GrammarNames.TokenFilePathWindows, filePathRegex);
+        public Terminal FilePathToken { get; } = new RegexBasedTerminal(GrammarNames.TokenFilePath, filePathRegex);
         #endregion
 
         #endregion
@@ -376,10 +376,10 @@ namespace XLParser
 
             Cell.Rule = CellToken;
 
-            File.Rule = FileToken
-                | EnclosedInBracketsToken
-                | FilePathWindowsToken + EnclosedInBracketsToken
-                | FilePathWindowsToken + FileNameWindowsToken
+            File.Rule = FileNameNumericToken
+                | FileNameEnclosedInBracketsToken
+                | FilePathToken + FileNameEnclosedInBracketsToken
+                | FilePathToken + FileName
                 ;
 
             DynamicDataExchange.Rule = File + exclamationMark + SingleQuotedStringToken;
@@ -401,7 +401,7 @@ namespace XLParser
             StructuredReferenceElement.Rule =
                   OpenSquareParen + SRColumnToken + CloseSquareParen
                 | OpenSquareParen + NameToken + CloseSquareParen
-                | EnclosedInBracketsToken;
+                | FileNameEnclosedInBracketsToken;
 
             //StructuredReferenceKeyword.Rule = EnclosedInBracketsToken;
 
@@ -598,9 +598,9 @@ namespace XLParser
         public const string TokenError = "ErrorToken";
         public const string TokenExcelRefFunction = "ExcelRefFunctionToken";
         public const string TokenExcelConditionalRefFunction = "ExcelConditionalRefFunctionToken";
-        public const string TokenFilePathWindows = "FilePathWindowsToken";
-        public const string TokenFileNameWindows = "FileNameWindowsToken";
-        public const string TokenEnclosedInBrackets = "EnclosedInBracketsToken";
+        public const string TokenFilePath = "FilePathToken";
+        public const string TokenFileName = "FileNameToken";
+        public const string TokenFileNameEnclosedInBrackets = "FileNameEnclosedInBracketsToken";
         public const string TokenFileNameNumeric = "FileNameNumericToken";
         public const string TokenHRange = "HRangeToken";
         public const string TokenIntersect = "INTERSECT";

--- a/src/XLParser/ParserReference.cs
+++ b/src/XLParser/ParserReference.cs
@@ -23,18 +23,20 @@ namespace XLParser
         public string LocationString { get; set; }
         public string Worksheet { get; set; }
         public string LastWorksheet { get; set; }
+        public string FilePath { get; set; }
         public string FileName { get; set; }
         public string Name { get; private set; }
         public string MinLocation { get; set; } //Location as appearing in the formula, eg $A$1
         public string MaxLocation { get; set; }
 
         public ParserReference(ReferenceType referenceType, string locationString = null, string worksheet = null, string lastWorksheet = null,
-            string fileName = null, string name = null, string minLocation = null, string maxLocation = null)
+            string filePath = null, string fileName = null, string name = null, string minLocation = null, string maxLocation = null)
         {
             ReferenceType = referenceType;
             LocationString = locationString;
             Worksheet = worksheet;
             LastWorksheet = lastWorksheet;
+            FilePath = filePath;
             FileName = fileName;
             Name = name;
             MinLocation = minLocation;
@@ -68,6 +70,11 @@ namespace XLParser
                         LastWorksheet = sheets[1];
                     }
 
+                    if (prefix.HasFilePath)
+                    {
+                        FilePath = prefix.FilePath;
+                    }
+
                     if (prefix.HasFileNumber)
                     {
                         FileName = prefix.FileNumber.ToString();
@@ -75,10 +82,6 @@ namespace XLParser
                     else if (prefix.HasFileName)
                     {
                         FileName = prefix.FileName;
-                    }
-                    else
-                    {
-                        FileName = null;
                     }
 
                     InitializeReference(node.ChildNodes[1]);

--- a/src/XLParser/PrefixInfo.cs
+++ b/src/XLParser/PrefixInfo.cs
@@ -84,13 +84,13 @@ namespace XLParser
                     // String filename
                     var iCur = 0;
                     // Check if it includes a path
-                    if (file.ChildNodes[iCur].Is(GrammarNames.TokenFilePathWindows))
+                    if (file.ChildNodes[iCur].Is(GrammarNames.TokenFilePath))
                     {
                         filePath = file.ChildNodes[iCur].Print();
                         iCur++;
                     }
 
-                    if (file.ChildNodes[iCur].Is(GrammarNames.TokenEnclosedInBrackets))
+                    if (file.ChildNodes[iCur].Is(GrammarNames.TokenFileNameEnclosedInBrackets))
                     {
                         fileName = Substr(file.ChildNodes[iCur].Print(), 1, 1);
                     }


### PR DESCRIPTION
This PR fixes several issues with external links in formulas. A whole variety of file paths can be used: standard (Windows) paths, network paths, relative paths, URLs. The regex that matches the file paths is improved to include all the edge cases.

Some sample formulas that can be parsed after merging this PR:

* `='C:\Users\Test\Desktop\[Book1.xlsx]Sheet1'!$A$1`
* `='\\TEST-01\Folder\[Book1.xlsx]Sheet1'!$A$1`
* `='http:\\example.com\test\[Book1.xlsx]Sheet1'!$A$1`
* `='Test\Folder\[Book1.xlsx]Sheet1'!$A$1`

This PR adds the relevant unit tests and includes some refactorings. Also, the file path is included in the parser references, generated by the formula analyzer.

Fixes #107. Fixes #108. Fixes #109.