### PR TITLE
add round brackets to urlpathregex for parsing external links

### DIFF
--- a/src/XLParser.Tests/FormulaAnalysisTest.cs
+++ b/src/XLParser.Tests/FormulaAnalysisTest.cs
@@ -370,6 +370,19 @@ namespace XLParser.Tests
         }
 
         [TestMethod]
+        public void ExternalWorkbookUrlPathHttpWithBracketsInDocument()
+        {
+            // See [#140](https://github.com/spreadsheetlab/XLParser/issues/140)
+
+            List<ParserReference> references = new FormulaAnalyzer(@"='http://example.com/testfolder(brackets)/[Book 1.xlsx]Sheet1'!$A$1").ParserReferences().ToList();
+
+            Assert.AreEqual(1, references.Count);
+            Assert.AreEqual(@"http://example.com/testfolder(brackets)/", references.First().FilePath);
+            Assert.AreEqual("Book 1.xlsx", references.First().FileName);
+            Assert.AreEqual("Sheet1", references.First().Worksheet);
+        }
+
+        [TestMethod]
         public void ExternalWorkbookRelativePath()
         {
             List<ParserReference> references = new FormulaAnalyzer(@"='Test\Folder\[Book1.xlsx]Sheet1'!$A$1").ParserReferences().ToList();

--- a/src/XLParser/ExcelFormulaGrammar.cs
+++ b/src/XLParser/ExcelFormulaGrammar.cs
@@ -185,7 +185,7 @@ namespace XLParser
         
         // Source: http://stackoverflow.com/a/6416209/572635
         private const string windowsFilePathRegex = @"(?:[a-zA-Z]:|\\?\\?[\w\.-]+\\[\w.$]+)\\(([^<>:""/\|?*\\]| )+\\)*";
-        private const string urlPathRegex = @"http(s?)\:\/\/[0-9a-zA-Z]([-.\w]*[0-9a-zA-Z])*(:(0-9)*)*(\/?)([a-zA-Z0-9\-\.\?\,\'\/\\\+&%\$#_]*)?";
+        private const string urlPathRegex = @"http(s?)\:\/\/[0-9a-zA-Z]([-.\w]*[0-9a-zA-Z])*(:(0-9)*)*(\/?)([a-zA-Z0-9\-\.\?\,\'\/\\\+&%\$#_()]*)?";
         private const string filePathRegex = @"(" + windowsFilePathRegex + @"|" + urlPathRegex + @")";
         public Terminal FilePathToken { get; } = new RegexBasedTerminal(GrammarNames.TokenFilePath, filePathRegex);
         #endregion

--- a/src/XLParser/ExcelFormulaGrammar.cs
+++ b/src/XLParser/ExcelFormulaGrammar.cs
@@ -185,7 +185,7 @@ namespace XLParser
         
         // Source: http://stackoverflow.com/a/6416209/572635
         private const string windowsFilePathRegex = @"(?:[a-zA-Z]:|\\?\\?[\w\.-]+\\[\w.$]+)\\(([^<>:""/\|?*\\]| )+\\)*";
-        private const string urlPathRegex = @"http(s?)\:\/\/[0-9a-zA-Z]([-.\w]*[0-9a-zA-Z])*(:(0-9)*)*(\/?)([a-zA-Z0-9\-\.\?\,\'\/\\\+&%\$#_()]*)?";
+        private const string urlPathRegex = @"http(s?)\:\/\/[0-9a-zA-Z]([-.\w]*[0-9a-zA-Z])*(:(0-9)*)*(\/?)([a-zA-Z0-9\-\.\?\,\'\/\\\+&%\$#_ ()]*)?";
         private const string filePathRegex = @"(" + windowsFilePathRegex + @"|" + urlPathRegex + @")";
         public Terminal FilePathToken { get; } = new RegexBasedTerminal(GrammarNames.TokenFilePath, filePathRegex);
         #endregion


### PR DESCRIPTION
add brackets to urlregex  , to make it possible to parse urls with brackets #140 .

Fixes #140