### PR TITLE
escape characters for name in brackets

### DIFF
--- a/src/XLParser.Tests/FormulaAnalysisTest.cs
+++ b/src/XLParser.Tests/FormulaAnalysisTest.cs
@@ -227,6 +227,46 @@ namespace XLParser.Tests
         }
 
         [TestMethod]
+        public void StructuredTableReferenceWithEscapedCharacterPound()
+        {
+            List<ParserReference> references = new FormulaAnalyzer("=SUBTOTAL(109,Table1[column header with '[])").ParserReferences().ToList();
+
+            Assert.AreEqual(1, references.Count);
+            Assert.AreEqual(ReferenceType.Table, references.First().ReferenceType);
+            Assert.AreEqual("Table1", references.First().Name);
+        }
+
+        [TestMethod]
+        public void StructuredTableReferenceWithEscapedCharacterBracketOpen()
+        {
+            List<ParserReference> references = new FormulaAnalyzer("COUNTA(Table1['[Header])").ParserReferences().ToList();
+
+            Assert.AreEqual(1, references.Count);
+            Assert.AreEqual(ReferenceType.Table, references.First().ReferenceType);
+            Assert.AreEqual("Table1", references.First().Name);
+        }
+
+        [TestMethod]
+        public void StructuredTableReferenceWithEscapedCharacterBracketClose()
+        {
+            List<ParserReference> references = new FormulaAnalyzer("COUNTA(Table1[']Header])").ParserReferences().ToList();
+
+            Assert.AreEqual(1, references.Count);
+            Assert.AreEqual(ReferenceType.Table, references.First().ReferenceType);
+            Assert.AreEqual("Table1", references.First().Name);
+        }
+
+        [TestMethod]
+        public void StructuredTableReferenceWithEscapedCharacterQuote()
+        {
+            List<ParserReference> references = new FormulaAnalyzer("COUNTA(Table1[''Header])").ParserReferences().ToList();
+
+            Assert.AreEqual(1, references.Count);
+            Assert.AreEqual(ReferenceType.Table, references.First().ReferenceType);
+            Assert.AreEqual("Table1", references.First().Name);
+        }
+
+        [TestMethod]
         public void StructuredTableReferenceCurrentRow()
         {
             List<ParserReference> references = new FormulaAnalyzer("COUNTA(Table1[@])").ParserReferences().ToList();
@@ -255,6 +295,29 @@ namespace XLParser.Tests
             Assert.AreEqual(ReferenceType.Table, references.First().ReferenceType);
             Assert.AreEqual("Table1", references.First().Name);
         }
+
+        [TestMethod]
+        public void UnqualifiedStructuredTableReference()
+        {
+            List<ParserReference> references = new FormulaAnalyzer("=SUBTOTAL(109,[Sales Amount])").ParserReferences().ToList();
+
+            Assert.AreEqual(1, references.Count);
+            Assert.AreEqual(ReferenceType.Table, references.First().ReferenceType);
+            Assert.AreEqual(null, references.First().Name);
+        }
+
+
+        [TestMethod]
+        public void UnqualifiedStructuredTableReferenceWithNumbers()
+        {
+            List<ParserReference> references = new FormulaAnalyzer("=SUBTOTAL(109,[2016])").ParserReferences().ToList();
+
+            Assert.AreEqual(1, references.Count);
+            Assert.AreEqual(ReferenceType.Table, references.First().ReferenceType);
+            Assert.AreEqual(null, references.First().Name);
+        }
+
+
 
         [TestMethod]
         public void SheetWithUnderscore()

--- a/src/XLParser/ExcelFormulaGrammar.cs
+++ b/src/XLParser/ExcelFormulaGrammar.cs
@@ -173,8 +173,8 @@ namespace XLParser
         private const string fileNameNumericRegex = @"\[[0-9]+\]";
         public Terminal FileNameNumericToken = new RegexBasedTerminal(GrammarNames.TokenFileNameNumeric, fileNameNumericRegex)
         { Priority = TerminalPriority.FileNameNumericToken };
-        
-        private const string fileNameInBracketsRegex = @"\[[^\[\]]+\]";
+
+        private const string fileNameInBracketsRegex = @"\[([^\[\]']|('['\[\]#@]))+\]";
         public Terminal FileNameEnclosedInBracketsToken { get; } = new RegexBasedTerminal(GrammarNames.TokenFileNameEnclosedInBrackets, fileNameInBracketsRegex)
         { Priority = TerminalPriority.FileName };
         
@@ -407,10 +407,11 @@ namespace XLParser
                 ;
 
             StructuredReferenceElement.Rule =
-                  OpenSquareParen + SRColumnToken + CloseSquareParen
+                OpenSquareParen + SRColumnToken + CloseSquareParen
                 | OpenSquareParen + NameToken + CloseSquareParen
-                | FileNameEnclosedInBracketsToken;
-
+                | FileNameEnclosedInBracketsToken
+                | FileNameNumericToken;
+                
             StructuredReferenceTable.Rule = NameToken;
 
             StructuredReferenceExpression.Rule =


### PR DESCRIPTION
add filennamenumeric to structured reference element
Fixes escape characters #147 and
unqualified Structured references #132 