### PR TITLE
Improve structured references

### DIFF
--- a/src/XLParser.Tests/FormulaAnalysisTest.cs
+++ b/src/XLParser.Tests/FormulaAnalysisTest.cs
@@ -257,6 +257,8 @@ namespace XLParser.Tests
             Assert.AreEqual(1, references.Count);
             Assert.AreEqual(ReferenceType.Table, references.First().ReferenceType);
             Assert.AreEqual("Table1", references.First().Name);
+            CollectionAssert.AreEqual(new[] {"#Headers"}, references.First().TableSpecifiers);
+            CollectionAssert.AreEqual(new string[] {}, references.First().TableColumns);
         }
 
         [TestMethod]
@@ -267,6 +269,8 @@ namespace XLParser.Tests
             Assert.AreEqual(1, references.Count);
             Assert.AreEqual(ReferenceType.Table, references.First().ReferenceType);
             Assert.AreEqual("Table1", references.First().Name);
+            CollectionAssert.AreEqual(new[] {"#This Row"}, references.First().TableSpecifiers);
+            CollectionAssert.AreEqual(new[] {"b"}, references.First().TableColumns);
         }
 
         [TestMethod]
@@ -277,6 +281,8 @@ namespace XLParser.Tests
             Assert.AreEqual(1, references.Count);
             Assert.AreEqual(ReferenceType.Table, references.First().ReferenceType);
             Assert.AreEqual("Table1", references.First().Name);
+            CollectionAssert.AreEqual(new[] {"@"}, references.First().TableSpecifiers);
+            CollectionAssert.AreEqual(new[] {"Region"}, references.First().TableColumns);
         }
 
         [TestMethod]
@@ -287,6 +293,8 @@ namespace XLParser.Tests
             Assert.AreEqual(1, references.Count);
             Assert.AreEqual(ReferenceType.Table, references.First().ReferenceType);
             Assert.AreEqual("Table1", references.First().Name);
+            CollectionAssert.AreEqual(new string[] {}, references.First().TableSpecifiers);
+            CollectionAssert.AreEqual(new[] {"Date", "Color"}, references.First().TableColumns);
         }
 
         [TestMethod]
@@ -297,46 +305,56 @@ namespace XLParser.Tests
             Assert.AreEqual(1, references.Count);
             Assert.AreEqual(ReferenceType.Table, references.First().ReferenceType);
             Assert.AreEqual("Table1", references.First().Name);
+            CollectionAssert.AreEqual(new[] {"#Totals"}, references.First().TableSpecifiers);
+            CollectionAssert.AreEqual(new[] {"Qty"}, references.First().TableColumns);
         }
 
         [TestMethod]
         public void StructuredTableReferenceWithEscapedCharacterPound()
         {
-            List<ParserReference> references = new FormulaAnalyzer("=SUBTOTAL(109,Table1[column header with '[])").ParserReferences().ToList();
+            List<ParserReference> references = new FormulaAnalyzer("=SUBTOTAL(109,Table1['#NumItems])").ParserReferences().ToList();
 
             Assert.AreEqual(1, references.Count);
             Assert.AreEqual(ReferenceType.Table, references.First().ReferenceType);
             Assert.AreEqual("Table1", references.First().Name);
+            CollectionAssert.AreEqual(new string[] {}, references.First().TableSpecifiers);
+            CollectionAssert.AreEqual(new[] {"#NumItems"}, references.First().TableColumns);
         }
 
         [TestMethod]
-        public void StructuredTableReferenceWithEscapedCharacterBracketOpen()
+        public void StructuredTableReferenceWithEscapedCharacterBracket()
         {
-            List<ParserReference> references = new FormulaAnalyzer("COUNTA(Table1['[Header])").ParserReferences().ToList();
+            List<ParserReference> references = new FormulaAnalyzer("COUNTA(Table1['[Header']])").ParserReferences().ToList();
 
             Assert.AreEqual(1, references.Count);
             Assert.AreEqual(ReferenceType.Table, references.First().ReferenceType);
             Assert.AreEqual("Table1", references.First().Name);
-        }
-
-        [TestMethod]
-        public void StructuredTableReferenceWithEscapedCharacterBracketClose()
-        {
-            List<ParserReference> references = new FormulaAnalyzer("COUNTA(Table1[']Header])").ParserReferences().ToList();
-
-            Assert.AreEqual(1, references.Count);
-            Assert.AreEqual(ReferenceType.Table, references.First().ReferenceType);
-            Assert.AreEqual("Table1", references.First().Name);
+            CollectionAssert.AreEqual(new string[] {}, references.First().TableSpecifiers);
+            CollectionAssert.AreEqual(new[] {"[Header]"}, references.First().TableColumns);
         }
 
         [TestMethod]
         public void StructuredTableReferenceWithEscapedCharacterQuote()
         {
-            List<ParserReference> references = new FormulaAnalyzer("COUNTA(Table1[''Header])").ParserReferences().ToList();
+            List<ParserReference> references = new FormulaAnalyzer("COUNTA(Table1[''Test''])").ParserReferences().ToList();
 
             Assert.AreEqual(1, references.Count);
             Assert.AreEqual(ReferenceType.Table, references.First().ReferenceType);
             Assert.AreEqual("Table1", references.First().Name);
+            CollectionAssert.AreEqual(new string[] {}, references.First().TableSpecifiers);
+            CollectionAssert.AreEqual(new[] {"'Test'"}, references.First().TableColumns);
+        }
+
+        [TestMethod]
+        public void StructuredTableReferenceUnqualified()
+        {
+            List<ParserReference> references = new FormulaAnalyzer("=SUBTOTAL(109,[Sales])").ParserReferences().ToList();
+
+            Assert.AreEqual(1, references.Count);
+            Assert.AreEqual(ReferenceType.Table, references.First().ReferenceType);
+            Assert.AreEqual(null, references.First().Name);
+            CollectionAssert.AreEqual(new string[] {}, references.First().TableSpecifiers);
+            CollectionAssert.AreEqual(new[] {"Sales"}, references.First().TableColumns);
         }
 
         [TestMethod]
@@ -347,16 +365,8 @@ namespace XLParser.Tests
             Assert.AreEqual(1, references.Count);
             Assert.AreEqual(ReferenceType.Table, references.First().ReferenceType);
             Assert.AreEqual(null, references.First().Name);
-        }
-
-        [TestMethod]
-        public void StructuredTableReferenceUnqualified()
-        {
-            List<ParserReference> references = new FormulaAnalyzer("=SUBTOTAL(109,[SalesAmount])").ParserReferences().ToList();
-
-            Assert.AreEqual(1, references.Count);
-            Assert.AreEqual(ReferenceType.Table, references.First().ReferenceType);
-            Assert.AreEqual(null, references.First().Name);
+            CollectionAssert.AreEqual(new string[] {}, references.First().TableSpecifiers);
+            CollectionAssert.AreEqual(new[] {"Sales Amount"}, references.First().TableColumns);
         }
 
         [TestMethod]
@@ -367,6 +377,32 @@ namespace XLParser.Tests
             Assert.AreEqual(1, references.Count);
             Assert.AreEqual(ReferenceType.Table, references.First().ReferenceType);
             Assert.AreEqual(null, references.First().Name);
+            CollectionAssert.AreEqual(new string[] {}, references.First().TableSpecifiers);
+            CollectionAssert.AreEqual(new[] {"2016"}, references.First().TableColumns);
+        }
+
+        [TestMethod]
+        public void StructuredTableReferenceMultipleColumnSpecifiers()
+        {
+            List<ParserReference> references = new FormulaAnalyzer("=DeptSales[[#All],[Sales Amount]:[Commission Amount]]").ParserReferences().ToList();
+
+            Assert.AreEqual(1, references.Count);
+            Assert.AreEqual(ReferenceType.Table, references.First().ReferenceType);
+            Assert.AreEqual("DeptSales", references.First().Name);
+            CollectionAssert.AreEqual(new[] {"#All"}, references.First().TableSpecifiers);
+            CollectionAssert.AreEqual(new[] {"Sales Amount", "Commission Amount"}, references.First().TableColumns);
+        }
+
+        [TestMethod]
+        public void StructuredTableReferenceMultipleItemSpecifiers()
+        {
+            List<ParserReference> references = new FormulaAnalyzer("=DeptSales[[#Headers],[#Data],[% Commission]]").ParserReferences().ToList();
+
+            Assert.AreEqual(1, references.Count);
+            Assert.AreEqual(ReferenceType.Table, references.First().ReferenceType);
+            Assert.AreEqual("DeptSales", references.First().Name);
+            CollectionAssert.AreEqual(new[] {"#Headers", "#Data"}, references.First().TableSpecifiers);
+            CollectionAssert.AreEqual(new[] {"% Commission"}, references.First().TableColumns);
         }
 
         [TestMethod]

--- a/src/XLParser.Tests/FormulaAnalysisTest.cs
+++ b/src/XLParser.Tests/FormulaAnalysisTest.cs
@@ -382,7 +382,7 @@ namespace XLParser.Tests
         }
 
         [TestMethod]
-        public void StructuredTableReferenceMultipleColumnSpecifiers()
+        public void StructuredTableReferenceSpecifierAndColumns()
         {
             List<ParserReference> references = new FormulaAnalyzer("=DeptSales[[#All],[Sales Amount]:[Commission Amount]]").ParserReferences().ToList();
 
@@ -394,7 +394,7 @@ namespace XLParser.Tests
         }
 
         [TestMethod]
-        public void StructuredTableReferenceMultipleItemSpecifiers()
+        public void StructuredTableReferenceSpecifiersAndColumn()
         {
             List<ParserReference> references = new FormulaAnalyzer("=DeptSales[[#Headers],[#Data],[% Commission]]").ParserReferences().ToList();
 
@@ -403,6 +403,63 @@ namespace XLParser.Tests
             Assert.AreEqual("DeptSales", references.First().Name);
             CollectionAssert.AreEqual(new[] {"#Headers", "#Data"}, references.First().TableSpecifiers);
             CollectionAssert.AreEqual(new[] {"% Commission"}, references.First().TableColumns);
+        }
+
+        [TestMethod]
+        public void StructuredTableReferenceMultipleRows()
+        {
+            List<ParserReference> references = new FormulaAnalyzer("=SUM([@Jan]:[@Feb])").ParserReferences().ToList();
+
+            Assert.AreEqual(2, references.Count);
+
+            Assert.AreEqual(ReferenceType.Table, references[0].ReferenceType);
+            Assert.AreEqual(null, references[0].Name);
+            CollectionAssert.AreEqual(new[] {"@"}, references[0].TableSpecifiers);
+            CollectionAssert.AreEqual(new[] {"Jan"}, references[0].TableColumns);
+
+            Assert.AreEqual(ReferenceType.Table, references[1].ReferenceType);
+            Assert.AreEqual(null, references[1].Name);
+            CollectionAssert.AreEqual(new[] {"@"}, references[1].TableSpecifiers);
+            CollectionAssert.AreEqual(new[] {"Feb"}, references[1].TableColumns);
+        }
+
+        [TestMethod]
+        public void StructuredTableReferenceMultipleColumns()
+        {
+            List<ParserReference> references = new FormulaAnalyzer("=XLOOKUP($G7,Sales[[Region]:[Region]],Sales[Mar])").ParserReferences().ToList();
+
+            Assert.AreEqual(3, references.Count);
+
+            Assert.AreEqual(ReferenceType.Cell, references[0].ReferenceType);
+            Assert.AreEqual("$G7", references[0].MinLocation);
+
+            Assert.AreEqual(ReferenceType.Table, references[1].ReferenceType);
+            Assert.AreEqual("Sales", references[1].Name);
+            CollectionAssert.AreEqual(new string[] {}, references[1].TableSpecifiers);
+            CollectionAssert.AreEqual(new[] {"Region", "Region"}, references[1].TableColumns);
+
+            Assert.AreEqual(ReferenceType.Table, references[2].ReferenceType);
+            Assert.AreEqual("Sales", references[2].Name);
+            CollectionAssert.AreEqual(new string[] {}, references[2].TableSpecifiers);
+            CollectionAssert.AreEqual(new[] {"Mar"}, references[2].TableColumns);
+        }
+
+        [TestMethod]
+        public void StructuredTableReferenceMultipleHeaders()
+        {
+            List<ParserReference> references = new FormulaAnalyzer("=COUNTA(Sales_5[[#Headers],[Jan]]:Sales_5[[#Headers],[Mar]])").ParserReferences().ToList();
+
+            Assert.AreEqual(2, references.Count);
+
+            Assert.AreEqual(ReferenceType.Table, references[0].ReferenceType);
+            Assert.AreEqual("Sales_5", references[0].Name);
+            CollectionAssert.AreEqual(new[] {"#Headers"}, references[0].TableSpecifiers);
+            CollectionAssert.AreEqual(new[] {"Jan"}, references[0].TableColumns);
+
+            Assert.AreEqual(ReferenceType.Table, references[1].ReferenceType);
+            Assert.AreEqual("Sales_5", references[1].Name);
+            CollectionAssert.AreEqual(new[] {"#Headers"}, references[1].TableSpecifiers);
+            CollectionAssert.AreEqual(new[] {"Mar"}, references[1].TableColumns);
         }
 
         [TestMethod]

--- a/src/XLParser/ExcelFormulaParser.cs
+++ b/src/XLParser/ExcelFormulaParser.cs
@@ -589,7 +589,7 @@ namespace XLParser
 
                 case GrammarNames.StructuredReference:
                     var sb = new StringBuilder();
-                    var hashtable = input.ChildNodes.Count >= 1 && input.ChildNodes[0].Is(GrammarNames.StructuredReferenceTable);
+                    var hashtable = input.ChildNodes.Count >= 1 && input.ChildNodes[0].Is(GrammarNames.StructuredReferenceQualifier);
                     var contentsNode = hashtable ? 1 : 0;
                     childrenList = children.ToList();
                     if (hashtable)
@@ -602,7 +602,7 @@ namespace XLParser
                         // Full table reference
                         sb.Append("[]");
                     }
-                    else if (input.ChildNodes[contentsNode].Is(GrammarNames.StructuredReferenceElement))
+                    else if (input.ChildNodes[contentsNode].Is(GrammarNames.StructuredReferenceSpecifier) || input.ChildNodes[contentsNode].Is(GrammarNames.StructuredReferenceColumn))
                     {
                         sb.Append(childrenList[contentsNode]);
                     }

--- a/src/XLParser/ExcelFormulaParser.cs
+++ b/src/XLParser/ExcelFormulaParser.cs
@@ -587,39 +587,16 @@ namespace XLParser
                 case GrammarNames.ArrayFormula:
                     return "{=" + children.ElementAt(1) + "}";
 
-                case GrammarNames.StructuredReference:
-                    var sb = new StringBuilder();
-                    var hashtable = input.ChildNodes.Count >= 1 && input.ChildNodes[0].Is(GrammarNames.StructuredReferenceQualifier);
-                    var contentsNode = hashtable ? 1 : 0;
-                    childrenList = children.ToList();
-                    if (hashtable)
-                    {
-                        sb.Append(childrenList[0]);
-                    }
-
-                    if (hashtable && input.ChildNodes.Count == 1)
-                    {
-                        // Full table reference
-                        sb.Append("[]");
-                    }
-                    else if (input.ChildNodes[contentsNode].Is(GrammarNames.StructuredReferenceSpecifier) || input.ChildNodes[contentsNode].Is(GrammarNames.StructuredReferenceColumn))
-                    {
-                        sb.Append(childrenList[contentsNode]);
-                    }
-                    else
-                    {
-                        sb.Append($"[{childrenList[contentsNode]}]");
-                    }
-
-                    return sb.ToString();
-
                 // Terms for which to print all child nodes concatenated
                 case GrammarNames.ArrayConstant:
                 case GrammarNames.DynamicDataExchange:
                 case GrammarNames.FormulaWithEq:
                 case GrammarNames.File:
                 case GrammarNames.MultiRangeFormula:
+                case GrammarNames.StructuredReference:
+                case GrammarNames.StructuredReferenceColumn:
                 case GrammarNames.StructuredReferenceExpression:
+                case GrammarNames.StructuredReferenceSpecifier:
                     return string.Join("", children);
 
                 // Terms for which we print the children comma-separated

--- a/src/XLParser/ParserReference.cs
+++ b/src/XLParser/ParserReference.cs
@@ -28,9 +28,12 @@ namespace XLParser
         public string Name { get; private set; }
         public string MinLocation { get; set; } //Location as appearing in the formula, eg $A$1
         public string MaxLocation { get; set; }
+        public string[] TableSpecifiers { get; set; }
+        public string[] TableColumns { get; set; }
 
         public ParserReference(ReferenceType referenceType, string locationString = null, string worksheet = null, string lastWorksheet = null,
-            string filePath = null, string fileName = null, string name = null, string minLocation = null, string maxLocation = null)
+            string filePath = null, string fileName = null, string name = null, string minLocation = null, string maxLocation = null,
+            string[] tableSpecifiers = null, string[] tableColumns = null)
         {
             ReferenceType = referenceType;
             LocationString = locationString;
@@ -41,6 +44,8 @@ namespace XLParser
             Name = name;
             MinLocation = minLocation;
             MaxLocation = maxLocation != null ? maxLocation : minLocation;
+            TableColumns = tableColumns;
+            TableSpecifiers = tableSpecifiers;
         }
 
         public ParserReference(ParseTreeNode node)
@@ -98,6 +103,8 @@ namespace XLParser
                 case GrammarNames.StructuredReference:
                     ReferenceType = ReferenceType.Table;
                     Name = node.ChildNodes.FirstOrDefault(x => x.Type() == GrammarNames.StructuredReferenceQualifier)?.ChildNodes[0].Token.ValueString;
+                    TableSpecifiers = node.AllNodes().Where(x => x.Is(GrammarNames.TokenSRSpecifier) || x.Is("@")).Select(x => UnEscape(x.Token.ValueString, "'")).ToArray();
+                    TableColumns = node.AllNodes().Where(x => x.Is(GrammarNames.TokenSRColumn)).Select(x => UnEscape(x.Token.ValueString, "'")).ToArray();
                     break;
                 case GrammarNames.HorizontalRange:
                     string[] horizontalLimits = node.ChildNodes[0].Token.ValueString.Split(':');
@@ -117,6 +124,11 @@ namespace XLParser
             }
 
             LocationString = node.Print();
+        }
+
+        private string UnEscape(string value, string escapeCharacter)
+        {
+            return System.Text.RegularExpressions.Regex.Replace(value, $"{escapeCharacter}(?!{escapeCharacter})", "");
         }
 
         /// <summary>

--- a/src/XLParser/ParserReference.cs
+++ b/src/XLParser/ParserReference.cs
@@ -97,7 +97,7 @@ namespace XLParser
                     break;
                 case GrammarNames.StructuredReference:
                     ReferenceType = ReferenceType.Table;
-                    Name = node.ChildNodes.FirstOrDefault(x => x.Type() == GrammarNames.StructuredReferenceTable)?.ChildNodes[0].Token.ValueString;
+                    Name = node.ChildNodes.FirstOrDefault(x => x.Type() == GrammarNames.StructuredReferenceQualifier)?.ChildNodes[0].Token.ValueString;
                     break;
                 case GrammarNames.HorizontalRange:
                     string[] horizontalLimits = node.ChildNodes[0].Token.ValueString.Split(':');


### PR DESCRIPTION
In this PR:

- Improved grammar of structured references
- New properties in `ParserReference`: `TableSpecifiers` and `TableColumns`
- Unit tests for the new properties in `TableSpecifiers` and `TableColumns`

Now all information about a structured reference is available in the `ParserReference` object.

Some examples:

- `Table1[[Date]:[Color]`
    - Name: `Table1`
    - TableSpecifiers: none
    - TableColumns: `Date`, `Color`
- `Table1[@Region]`
    - Name: `Table1`
    - TableSpecifiers: `@`
    - TableColumns: `Region`
- `DeptSales[[#Headers],[#Data],[% Commission]]`
    - Name: `DeptSales`
    - TableSpecifiers: `#Headers`, `#Data`
    - TableColumns: `% Commission`