### PR TITLE
Merge intersection of table references

### DIFF
--- a/src/XLParser.Tests/FormulaAnalysisTest.cs
+++ b/src/XLParser.Tests/FormulaAnalysisTest.cs
@@ -452,6 +452,48 @@ namespace XLParser.Tests
         }
 
         [TestMethod]
+        public void StructuredTableReferenceIntersectColumns()
+        {
+            List<ParserReference> references = new FormulaAnalyzer("=SUM(Sales_2[Jan]:Sales_2[Feb])").ParserReferences().ToList();
+
+            Assert.AreEqual(1, references.Count);
+            Assert.AreEqual(ReferenceType.Table, references.First().ReferenceType);
+            Assert.AreEqual("Sales_2", references.First().Name);
+            CollectionAssert.AreEqual(new string[] {}, references.First().TableSpecifiers);
+            CollectionAssert.AreEqual(new[] {"Jan", "Feb"}, references.First().TableColumns);
+        }
+
+        [TestMethod]
+        public void StructuredTableReferenceIntersectDifferentSpecifiers()
+        {
+            List<ParserReference> references = new FormulaAnalyzer("=COUNTA(Sales_2[[#Headers],[Jan]]:Sales_2[[#Data],[Feb]])").ParserReferences().ToList();
+
+            Assert.AreEqual(1, references.Count);
+            Assert.AreEqual(ReferenceType.Table, references.First().ReferenceType);
+            Assert.AreEqual("Sales_2", references.First().Name);
+            CollectionAssert.AreEqual(new string[] {}, references.First().TableSpecifiers);
+            CollectionAssert.AreEqual(new[] {"Jan", "Feb"}, references.First().TableColumns);
+        }
+
+        [TestMethod]
+        public void StructuredTableReferenceIntersectDifferentTables()
+        {
+            List<ParserReference> references = new FormulaAnalyzer("=COUNTA(Sales_2[Jan]:Sales_4[Feb])").ParserReferences().ToList();
+
+            Assert.AreEqual(2, references.Count);
+
+            Assert.AreEqual(ReferenceType.Table, references[0].ReferenceType);
+            Assert.AreEqual("Sales_2", references[0].Name);
+            CollectionAssert.AreEqual(new string[] {}, references[0].TableSpecifiers);
+            CollectionAssert.AreEqual(new[] {"Jan"}, references[0].TableColumns);
+
+            Assert.AreEqual(ReferenceType.Table, references[1].ReferenceType);
+            Assert.AreEqual("Sales_4", references[1].Name);
+            CollectionAssert.AreEqual(new string[] {}, references[1].TableSpecifiers);
+            CollectionAssert.AreEqual(new[] {"Feb"}, references[1].TableColumns);
+        }
+
+        [TestMethod]
         public void SheetWithUnderscore()
         {
             ParseTree parseResult = ExcelFormulaParser.ParseToTree("aap_noot!B12");

--- a/src/XLParser.Tests/FormulaAnalysisTest.cs
+++ b/src/XLParser.Tests/FormulaAnalysisTest.cs
@@ -1,11 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
+﻿using System.Collections.Generic;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Irony.Parsing;
-using System.Globalization;
-using XLParser;
 
 namespace XLParser.Tests
 {

--- a/src/XLParser.Tests/FormulaAnalysisTest.cs
+++ b/src/XLParser.Tests/FormulaAnalysisTest.cs
@@ -410,17 +410,11 @@ namespace XLParser.Tests
         {
             List<ParserReference> references = new FormulaAnalyzer("=SUM([@Jan]:[@Feb])").ParserReferences().ToList();
 
-            Assert.AreEqual(2, references.Count);
-
-            Assert.AreEqual(ReferenceType.Table, references[0].ReferenceType);
-            Assert.AreEqual(null, references[0].Name);
-            CollectionAssert.AreEqual(new[] {"@"}, references[0].TableSpecifiers);
-            CollectionAssert.AreEqual(new[] {"Jan"}, references[0].TableColumns);
-
-            Assert.AreEqual(ReferenceType.Table, references[1].ReferenceType);
-            Assert.AreEqual(null, references[1].Name);
-            CollectionAssert.AreEqual(new[] {"@"}, references[1].TableSpecifiers);
-            CollectionAssert.AreEqual(new[] {"Feb"}, references[1].TableColumns);
+            Assert.AreEqual(1, references.Count);
+            Assert.AreEqual(ReferenceType.Table, references.First().ReferenceType);
+            Assert.AreEqual(null, references.First().Name);
+            CollectionAssert.AreEqual(new[] {"@"}, references.First().TableSpecifiers);
+            CollectionAssert.AreEqual(new[] {"Jan", "Feb"}, references.First().TableColumns);
         }
 
         [TestMethod]
@@ -449,17 +443,12 @@ namespace XLParser.Tests
         {
             List<ParserReference> references = new FormulaAnalyzer("=COUNTA(Sales_5[[#Headers],[Jan]]:Sales_5[[#Headers],[Mar]])").ParserReferences().ToList();
 
-            Assert.AreEqual(2, references.Count);
+            Assert.AreEqual(1, references.Count);
 
             Assert.AreEqual(ReferenceType.Table, references[0].ReferenceType);
             Assert.AreEqual("Sales_5", references[0].Name);
             CollectionAssert.AreEqual(new[] {"#Headers"}, references[0].TableSpecifiers);
-            CollectionAssert.AreEqual(new[] {"Jan"}, references[0].TableColumns);
-
-            Assert.AreEqual(ReferenceType.Table, references[1].ReferenceType);
-            Assert.AreEqual("Sales_5", references[1].Name);
-            CollectionAssert.AreEqual(new[] {"#Headers"}, references[1].TableSpecifiers);
-            CollectionAssert.AreEqual(new[] {"Mar"}, references[1].TableColumns);
+            CollectionAssert.AreEqual(new[] {"Jan", "Mar"}, references[0].TableColumns);
         }
 
         [TestMethod]

--- a/src/XLParser/ExcelFormulaParser.cs
+++ b/src/XLParser/ExcelFormulaParser.cs
@@ -435,6 +435,13 @@ namespace XLParser
                             range.LocationString = node.Print();
                             list.Add(range);
                         }
+                        else if (IsTableReference(rangeStart) && IsTableReference(rangeEnd) && rangeStart.First().Name == rangeEnd.First().Name && rangeStart.First().TableColumns.Length == 1 && rangeEnd.First().TableColumns.Length == 1)
+                        {
+                            ParserReference range = rangeStart.First();
+                            range.TableColumns = rangeStart.First().TableColumns.Concat(rangeEnd.First().TableColumns).ToArray();
+                            range.TableSpecifiers = rangeStart.First().TableSpecifiers.SequenceEqual(rangeEnd.First().TableSpecifiers) ? range.TableSpecifiers : new string[0];
+                            list.Add(range);
+                        }
                         else
                         {
                             list.AddRange(rangeStart);
@@ -455,13 +462,17 @@ namespace XLParser
             return references.Count == 1 && references.First().ReferenceType == ReferenceType.Cell;
         }
 
+        private static bool IsTableReference(IList<ParserReference> references)
+        {
+            return references.Count == 1 && references.First().ReferenceType == ReferenceType.Table;
+        }
+
         /// <summary>
         /// Whether or not this node represents a range
         /// </summary>
         public static bool IsRange(this ParseTreeNode input)
         {
-            return input.IsBinaryReferenceOperation() &&
-                       input.ChildNodes[1].Is(":");
+            return input.IsBinaryReferenceOperation() && input.ChildNodes[1].Is(":");
         }
 
         /// <summary>


### PR DESCRIPTION
This PR improves the `ParserReference` of structured (table) references. Consider the following formula:

```=SUM(Sales_2[Jan]:Sales_2[Feb])```

Currently two parser references are generated. In fact, it can be seen as one table reference with two columns. Similar to cell ranges (e.g. A1:B10), would like to merge these two parser references into one parser reference. This PR provides the implementation and unit tests.

Some remarks:

- Table references are only merged if they are combined with the intersect operator `:`
- Table references are only merged if they refer to the same table
- Table references are only merged if they each refer to one column
- The table specifier is only taken over if it the same in both references. Otherwise, no specifier is applied.