### PR TITLE
Don't require extra chars at the end of NameCombinationToken

### DIFF
--- a/src/XLParser.Tests/ParserTests.cs
+++ b/src/XLParser.Tests/ParserTests.cs
@@ -880,7 +880,7 @@ namespace XLParser.Tests
         {
             // See [Issue 46](https://github.com/spreadsheetlab/XLParser/issues/46)
             // This concerns names beginning with non-name words.
-            var names = new[] {"A1ABC", "A1A1", "A2.PART_NUM", "A2?PART_NUM", "TRUEFOO", "FALSEFOO", "TRUEMODEL"};
+            var names = new[] {"A1ABC", "A1A1", "A2.PART_NUM", "A2?PART_NUM", "TRUEFOO", "FALSEFOO", "TRUEMODEL", "W1."};
             foreach (var name in names)
             {
                 Test(name, tree => tree.AllNodes(GrammarNames.NamedRange).Select(ExcelFormulaParser.Print).Contains(name));

--- a/src/XLParser/ExcelFormulaGrammar.cs
+++ b/src/XLParser/ExcelFormulaGrammar.cs
@@ -148,7 +148,7 @@ namespace XLParser
             ;
 
         // To prevent e.g. "A1A1" being parsed as 2 cell tokens
-        public Terminal NamedRangeCombinationToken { get; } = new RegexBasedTerminal(GrammarNames.TokenNamedRangeCombination, NameInvalidWordsRegex + NameValidCharacterRegex + "+",
+        public Terminal NamedRangeCombinationToken { get; } = new RegexBasedTerminal(GrammarNames.TokenNamedRangeCombination, NameInvalidWordsRegex,
                 ColumnPrefix.Concat(new[] { "T", "F" }).ToArray())
         { Priority = TerminalPriority.NamedRangeCombination };
 


### PR DESCRIPTION
Resolves #165.

It seems that the `NameValidCharacterRegex + "+"` is a redundant, because it is already contained within both branches of the `NameInvalidWordsRegex`. Because of the `"+"` at the end, the regex requires an extra characters at the end and can't parse named ranges that are cell-like address and one char.
