### PR TITLE
Add the support for different separator for arguments since it can vary based on the culture

### DIFF
--- a/src/XLParser.Tests/ParserTests.cs
+++ b/src/XLParser.Tests/ParserTests.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Text.RegularExpressions;
+using System.Threading;
 using Irony.Parsing;
 
 namespace XLParser.Tests
@@ -968,6 +970,21 @@ namespace XLParser.Tests
             Test("='\\\\TEST-01\\Folder\\[Book1.xlsx]Sheet1'!$A$1+'\\\\TEST-01\\[Folder]\\[Book1.xlsx]Sheet1'!$A$2",
                 tree =>
                     tree.AllNodes().Count(x => x.Is(GrammarNames.Reference)) == 2);
+        }
+        
+        [TestMethod]
+        public void EnsureSupportDifferentSeparatorForArguments()
+        {
+            var previousCulture = Thread.CurrentThread.CurrentCulture;
+            try
+            {
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("fr-CA");
+                Test("OR(A1=0;A2=2)");
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentCulture = previousCulture;
+            }
         }
     }
 }

--- a/src/XLParser/ExcelFormulaGrammar.cs
+++ b/src/XLParser/ExcelFormulaGrammar.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 
 namespace XLParser
 {
@@ -327,7 +328,8 @@ namespace XLParser
 
             FunctionName.Rule = ExcelFunction;
 
-            Arguments.Rule = MakeStarRule(Arguments, comma, Argument);
+            var listSeparator = Thread.CurrentThread.CurrentCulture.TextInfo.ListSeparator;
+            Arguments.Rule = MakeStarRule(Arguments, listSeparator == ";" ? semicolon : comma, Argument);
 
             EmptyArgument.Rule = EmptyArgumentToken;
             Argument.Rule = Formula | EmptyArgument;

--- a/src/XLParser/XLParser.csproj
+++ b/src/XLParser/XLParser.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452;net461;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net452;net461;netstandard2.0</TargetFrameworks>
     <Authors>TU Delft Spreadsheet Lab, Infotron</Authors>
     <Company>TU Delft Spreadsheet Lab, Infotron</Company>
     <PackageId>XLParser</PackageId>
@@ -28,7 +28,7 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <DefineConstants>$(DefineConstants);_NET461_</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <DefineConstants>$(DefineConstants);_NETSTANDARD_</DefineConstants>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Hi,

I would like to add the support for different separator for arguments since it can vary based on the culture.

> By default, Excel uses the list separator defined under regional settings in Control Panel. The US English version of Excel uses a comma (,) for list separator by default, while other international versions may use a semicolon (;).

For more infos: https://exceljet.net/glossary/list-separator

- I used Thread.CurrentThread.CurrentCulture.TextInfo.ListSeparator to identify whether it's a comma or semicolon.
- I considered the cached parser in ExcelFormulaParser and I update it if the culture change.
- I added a unit test to demonstrate that it works.
- I was forced to update netstandard1.6 to netstandard2.0 to use Thread.CurrentThread.

Feel free to integrate the change as you want. Consider the pull request as a suggestion. Maybe there is better way to do it.

Thanks!