### PR TITLE
Target netstandard2.0

### DIFF
--- a/app/XLParser.Web/XLParser Web.csproj
+++ b/app/XLParser.Web/XLParser Web.csproj
@@ -41,8 +41,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Irony, Version=1.1.11.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Irony.NetCore.1.1.11\lib\netstandard2.0\Irony.dll</HintPath>
+    <Reference Include="Irony, Version=1.1.0.0, Culture=neutral, PublicKeyToken=ca48ace7223ead47, processorArchitecture=MSIL">
+      <HintPath>..\packages\Irony.1.2.0\lib\netstandard2.0\Irony.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/app/XLParser.Web/packages.config
+++ b/app/XLParser.Web/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Irony.NetCore" version="1.1.11" targetFramework="net472" />
+  <package id="Irony" version="1.2.0" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net45" />
   <package id="System.Reflection.Emit.ILGeneration" version="4.7.0" targetFramework="net472" />
   <package id="System.Reflection.Emit.Lightweight" version="4.7.0" targetFramework="net472" />

--- a/lib/IronyExplorer/src/IronyExplorer.GrammarExplorer/App.config
+++ b/lib/IronyExplorer/src/IronyExplorer.GrammarExplorer/App.config
@@ -6,7 +6,7 @@
         </sectionGroup>
     </configSections>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
     </startup>
     <userSettings>
         <IronyExplorer.GrammarExplorer.Properties.Settings>

--- a/lib/IronyExplorer/src/IronyExplorer.GrammarExplorer/IronyExplorer.GrammarExplorer.csproj
+++ b/lib/IronyExplorer/src/IronyExplorer.GrammarExplorer/IronyExplorer.GrammarExplorer.csproj
@@ -35,11 +35,11 @@
     <Reference Include="FastColoredTextBox">
       <HintPath>..\..\libs\FastColoredTextBox\FastColoredTextBox.dll</HintPath>
     </Reference>
-    <Reference Include="Irony, Version=1.0.11.0, Culture=neutral, PublicKeyToken=ca48ace7223ead47, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Irony.NetCore.1.0.11\lib\net461\Irony.dll</HintPath>
+    <Reference Include="Irony, Version=1.1.0.0, Culture=neutral, PublicKeyToken=ca48ace7223ead47, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Irony.1.2.0\lib\netstandard2.0\Irony.dll</HintPath>
     </Reference>
-    <Reference Include="Irony.Interpreter, Version=1.0.11.0, Culture=neutral, PublicKeyToken=ca48ace7223ead47, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Irony.Interpreter.NetCore.1.0.11\lib\net461\Irony.Interpreter.dll</HintPath>
+    <Reference Include="Irony.Interpreter, Version=1.1.0.0, Culture=neutral, PublicKeyToken=ca48ace7223ead47, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Irony.Interpreter.1.2.0\lib\netstandard2.0\Irony.Interpreter.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/lib/IronyExplorer/src/IronyExplorer.GrammarExplorer/IronyExplorer.GrammarExplorer.csproj
+++ b/lib/IronyExplorer/src/IronyExplorer.GrammarExplorer/IronyExplorer.GrammarExplorer.csproj
@@ -8,7 +8,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>IronyExplorer.GrammarExplorer</RootNamespace>
     <AssemblyName>IronyExplorer.GrammarExplorer</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>

--- a/lib/IronyExplorer/src/IronyExplorer.GrammarExplorer/packages.config
+++ b/lib/IronyExplorer/src/IronyExplorer.GrammarExplorer/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Irony.Interpreter.NetCore" version="1.0.11" targetFramework="net461" />
-  <package id="Irony.NetCore" version="1.0.11" targetFramework="net461" />
-  <package id="System.Reflection.Emit.ILGeneration" version="4.3.0" targetFramework="net461" />
-  <package id="System.Reflection.Emit.Lightweight" version="4.3.0" targetFramework="net461" />
+  <package id="Irony.Interpreter.NetCore" version="1.0.11" targetFramework="net472" />
+  <package id="Irony.NetCore" version="1.0.11" targetFramework="net472" />
+  <package id="System.Reflection.Emit.ILGeneration" version="4.3.0" targetFramework="net472" />
+  <package id="System.Reflection.Emit.Lightweight" version="4.3.0" targetFramework="net472" />
 </packages>

--- a/lib/IronyExplorer/src/IronyExplorer.GrammarExplorer/packages.config
+++ b/lib/IronyExplorer/src/IronyExplorer.GrammarExplorer/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Irony.Interpreter.NetCore" version="1.0.11" targetFramework="net472" />
-  <package id="Irony.NetCore" version="1.0.11" targetFramework="net472" />
+  <package id="Irony" version="1.2.0" targetFramework="net472" />
+  <package id="Irony.Interpreter" version="1.2.0" targetFramework="net472" />
   <package id="System.Reflection.Emit.ILGeneration" version="4.3.0" targetFramework="net472" />
   <package id="System.Reflection.Emit.Lightweight" version="4.3.0" targetFramework="net472" />
 </packages>

--- a/src/XLParser.Tests/XLParser.Tests.csproj
+++ b/src/XLParser.Tests/XLParser.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;net461;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net462;net6</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\signing.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Irony.NetCore" Version="1.0.11" />
+    <PackageReference Include="Irony" Version="1.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />

--- a/src/XLParser/XLParser.csproj
+++ b/src/XLParser/XLParser.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452;net461;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
     <Authors>TU Delft Spreadsheet Lab, Infotron</Authors>
     <Company>TU Delft Spreadsheet Lab, Infotron</Company>
     <PackageId>XLParser</PackageId>
@@ -34,6 +34,6 @@
     <EmbeddedResource Include="Resources\ExcelBuiltinFunctionList.txt" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Irony.NetCore" Version="1.0.11" />
+    <PackageReference Include="Irony" Version="1.2.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
See issue #176.

Notes:
- Should the changelog be updated? I did not do it for now, as it seems to be not quite up to date.
- Changed the `TargetFrameworks` for XLParser.Tests to `net462;net6`, as `netcoreapp3.1` is also out of support