### PR TITLE
Fixed issues related to external workbook url path

### DIFF
--- a/src/XLParser.Tests/FormulaAnalysisTest.cs
+++ b/src/XLParser.Tests/FormulaAnalysisTest.cs
@@ -648,13 +648,37 @@ namespace XLParser.Tests
         }
 
         [TestMethod]
-        public void ExternalWorkbookUrlPathHttpWithPortNUmberInPath()
+        public void ExternalWorkbookUrlPathHttpWithPortNumberInPath()
         {
             // See [#194](https://github.com/spreadsheetlab/XLParser/issues/194)
             List<ParserReference> references = new FormulaAnalyzer(@"='http://example.com:1234/test/[Book1.xlsx]Sheet1'!$A$1").ParserReferences().ToList();
 
             Assert.AreEqual(1, references.Count);
             Assert.AreEqual(@"http://example.com:1234/test/", references.First().FilePath);
+            Assert.AreEqual("Book1.xlsx", references.First().FileName);
+            Assert.AreEqual("Sheet1", references.First().Worksheet);
+        }
+
+        [TestMethod]
+        public void ExternalWorkbookUrlPathHttpWithSpecialLetters()
+        {
+            // See [#192](https://github.com/spreadsheetlab/XLParser/issues/192)
+            List<ParserReference> references = new FormulaAnalyzer(@"='http://example.com/tëst/[Book1.xlsx]Sheet1'!$A$1").ParserReferences().ToList();
+
+            Assert.AreEqual(1, references.Count);
+            Assert.AreEqual(@"http://example.com/tëst/", references.First().FilePath);
+            Assert.AreEqual("Book1.xlsx", references.First().FileName);
+            Assert.AreEqual("Sheet1", references.First().Worksheet);
+        }
+
+        [TestMethod]
+        public void ExternalWorkbookUrlPathHttpWithEscapedSingleQuote()
+        {
+            // See [#193](https://github.com/spreadsheetlab/XLParser/issues/193)
+            List<ParserReference> references = new FormulaAnalyzer(@"='http://example.com/test''/[Book1.xlsx]Sheet1'!$A$1").ParserReferences().ToList();
+
+            Assert.AreEqual(1, references.Count);
+            Assert.AreEqual(@"http://example.com/test'/", references.First().FilePath);
             Assert.AreEqual("Book1.xlsx", references.First().FileName);
             Assert.AreEqual("Sheet1", references.First().Worksheet);
         }

--- a/src/XLParser.Tests/FormulaAnalysisTest.cs
+++ b/src/XLParser.Tests/FormulaAnalysisTest.cs
@@ -648,6 +648,18 @@ namespace XLParser.Tests
         }
 
         [TestMethod]
+        public void ExternalWorkbookUrlPathHttpWithPortNUmberInPath()
+        {
+            // See [#194](https://github.com/spreadsheetlab/XLParser/issues/194)
+            List<ParserReference> references = new FormulaAnalyzer(@"='http://example.com:1234/test/[Book1.xlsx]Sheet1'!$A$1").ParserReferences().ToList();
+
+            Assert.AreEqual(1, references.Count);
+            Assert.AreEqual(@"http://example.com:1234/test/", references.First().FilePath);
+            Assert.AreEqual("Book1.xlsx", references.First().FileName);
+            Assert.AreEqual("Sheet1", references.First().Worksheet);
+        }
+
+        [TestMethod]
         public void ExternalWorkbookNetworkPathWithSpace()
         {
             // See [#142](https://github.com/spreadsheetlab/XLParser/issues/142)
@@ -798,7 +810,7 @@ namespace XLParser.Tests
             Assert.AreEqual("Book (1).xlsx", references.First().FileName);
             Assert.AreEqual("Sheet1", references.First().Worksheet);
         }
-
+       
         [TestMethod]
         public void ExternalWorkbookPathWithRoundBracketsInDocument()
         {

--- a/src/XLParser/ExcelFormulaGrammar.cs
+++ b/src/XLParser/ExcelFormulaGrammar.cs
@@ -205,7 +205,7 @@ namespace XLParser
 
         // Source: http://stackoverflow.com/a/6416209/572635
         private const string windowsFilePathRegex = @"(?:[a-zA-Z]:|\\?\\?[\w\-.$ @]+)\\(([^<>\"" /\|?*\\']|( |''))*\\)*";
-        private const string urlPathRegex = @"http(s?)\:\/\/[\p{L}\p{N}]([-.\w]*[\p{L}])*(:[0-9]+)?/([\p{L}\p{N}\-\.\?\,\'+&%\$#_ ()]*[/])*";
+        private const string urlPathRegex = @"http(s?)\://([\p{L}\p{N}-_]+\.[\p{L}\p{N}-_]*)+(:[0-9]+)?/([\p{L}\p{N}\-\.\?\,\'+&%\$#_ ()]*/)*";
         private const string filePathRegex = @"(" + windowsFilePathRegex + @"|" + urlPathRegex + @")";
         public Terminal FilePathToken { get; } = new RegexBasedTerminal(GrammarNames.TokenFilePath, filePathRegex)
         { Priority = TerminalPriority.FileNamePath };

--- a/src/XLParser/ExcelFormulaGrammar.cs
+++ b/src/XLParser/ExcelFormulaGrammar.cs
@@ -205,7 +205,7 @@ namespace XLParser
 
         // Source: http://stackoverflow.com/a/6416209/572635
         private const string windowsFilePathRegex = @"(?:[a-zA-Z]:|\\?\\?[\w\-.$ @]+)\\(([^<>\"" /\|?*\\']|( |''))*\\)*";
-        private const string urlPathRegex = @"http(s?)\:\/\/\p{L}([-.\w]*[\p{L}])*(:[0-9]*)*[/]([\p{L}0-9\-\.\?\,\'+&%\$#_ ()]*[/])*";
+        private const string urlPathRegex = @"http(s?)\:\/\/[\p{L}\p{M}]([-.\w]*[\p{L}\p{M}])*(:[0-9]*)*[/]([\p{L}\p{M}0-9\-\.\?\,\'+&%\$#_ ()]*[/])*";
         private const string filePathRegex = @"(" + windowsFilePathRegex + @"|" + urlPathRegex + @")";
         public Terminal FilePathToken { get; } = new RegexBasedTerminal(GrammarNames.TokenFilePath, filePathRegex)
         { Priority = TerminalPriority.FileNamePath };

--- a/src/XLParser/ExcelFormulaGrammar.cs
+++ b/src/XLParser/ExcelFormulaGrammar.cs
@@ -205,7 +205,7 @@ namespace XLParser
 
         // Source: http://stackoverflow.com/a/6416209/572635
         private const string windowsFilePathRegex = @"(?:[a-zA-Z]:|\\?\\?[\w\-.$ @]+)\\(([^<>\"" /\|?*\\']|( |''))*\\)*";
-        private const string urlPathRegex = @"http(s?)\:\/\/[\p{L}\p{M}]([-.\w]*[\p{L}\p{M}])*(:[0-9]*)*[/]([\p{L}\p{M}0-9\-\.\?\,\'+&%\$#_ ()]*[/])*";
+        private const string urlPathRegex = @"http(s?)\:\/\/[\p{L}0-9]([-.\w]*[\p{L}])*(:[0-9]+)?/([\p{L}0-9\-\.\?\,\'+&%\$#_ ()]*[/])*";
         private const string filePathRegex = @"(" + windowsFilePathRegex + @"|" + urlPathRegex + @")";
         public Terminal FilePathToken { get; } = new RegexBasedTerminal(GrammarNames.TokenFilePath, filePathRegex)
         { Priority = TerminalPriority.FileNamePath };

--- a/src/XLParser/ExcelFormulaGrammar.cs
+++ b/src/XLParser/ExcelFormulaGrammar.cs
@@ -205,7 +205,7 @@ namespace XLParser
 
         // Source: http://stackoverflow.com/a/6416209/572635
         private const string windowsFilePathRegex = @"(?:[a-zA-Z]:|\\?\\?[\w\-.$ @]+)\\(([^<>\"" /\|?*\\']|( |''))*\\)*";
-        private const string urlPathRegex = @"http(s?)\:\/\/[0-9a-zA-Z]([-.\w]*[0-9a-zA-Z])*(:(0-9)*)*[/]([a-zA-Z0-9\-\.\?\,\'+&%\$#_ ()]*[/])*";
+        private const string urlPathRegex = @"http(s?)\:\/\/\p{L}([-.\w]*[\p{L}])*(:[0-9]*)*[/]([\p{L}0-9\-\.\?\,\'+&%\$#_ ()]*[/])*";
         private const string filePathRegex = @"(" + windowsFilePathRegex + @"|" + urlPathRegex + @")";
         public Terminal FilePathToken { get; } = new RegexBasedTerminal(GrammarNames.TokenFilePath, filePathRegex)
         { Priority = TerminalPriority.FileNamePath };

--- a/src/XLParser/ExcelFormulaGrammar.cs
+++ b/src/XLParser/ExcelFormulaGrammar.cs
@@ -205,7 +205,7 @@ namespace XLParser
 
         // Source: http://stackoverflow.com/a/6416209/572635
         private const string windowsFilePathRegex = @"(?:[a-zA-Z]:|\\?\\?[\w\-.$ @]+)\\(([^<>\"" /\|?*\\']|( |''))*\\)*";
-        private const string urlPathRegex = @"http(s?)\:\/\/[\p{L}0-9]([-.\w]*[\p{L}])*(:[0-9]+)?/([\p{L}0-9\-\.\?\,\'+&%\$#_ ()]*[/])*";
+        private const string urlPathRegex = @"http(s?)\:\/\/[\p{L}\p{N}]([-.\w]*[\p{L}])*(:[0-9]+)?/([\p{L}\p{N}\-\.\?\,\'+&%\$#_ ()]*[/])*";
         private const string filePathRegex = @"(" + windowsFilePathRegex + @"|" + urlPathRegex + @")";
         public Terminal FilePathToken { get; } = new RegexBasedTerminal(GrammarNames.TokenFilePath, filePathRegex)
         { Priority = TerminalPriority.FileNamePath };

--- a/src/XLParser/ParserReference.cs
+++ b/src/XLParser/ParserReference.cs
@@ -59,7 +59,7 @@ namespace XLParser
 
                     if (prefix.HasFilePath)
                     {
-                        FilePath = prefix.FilePath;
+                        FilePath = prefix.FilePath.Replace("''", "'");
                     }
 
                     if (prefix.HasFileNumber)


### PR DESCRIPTION
Fixed an issue with the urlPathRegex so it can parse port numbers now. Closes #194 
Added support for all letter characters in urlPathRegex. Closes #192 
Changed the conversion from prefix to filepath to replace escaped single quotes with a single quote. Closes #193