### PR TITLE
Update packages

### DIFF
--- a/src/XLParser.Tests/DatasetTests.cs
+++ b/src/XLParser.Tests/DatasetTests.cs
@@ -65,9 +65,7 @@ namespace XLParser.Tests
                     {
                         lock (lockObj)
                         {
-#if !_NET6_
                             TestContext.WriteLine($"Failed parsing line {lineNumber} <<{formula}>>");
-#endif
                             parseErrors++;
                         }
                     }

--- a/src/XLParser.Tests/XLParser.Tests.csproj
+++ b/src/XLParser.Tests/XLParser.Tests.csproj
@@ -16,9 +16,9 @@
 
   <ItemGroup>
     <PackageReference Include="Irony" Version="1.5.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/XLParser.Tests/XLParser.Tests.csproj
+++ b/src/XLParser.Tests/XLParser.Tests.csproj
@@ -6,14 +6,6 @@
     <AssemblyOriginatorKeyFile>..\signing.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DefineConstants>TRACE;DEBUG</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net6'">
-    <DefineConstants>$(DefineConstants);_NET6_</DefineConstants>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Irony" Version="1.5.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />

--- a/src/XLParser.Tests/XLParser.Tests.csproj
+++ b/src/XLParser.Tests/XLParser.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net6</TargetFrameworks>
+    <TargetFrameworks>net462;net8.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\signing.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/XLParser.Tests/XLParser.Tests.csproj
+++ b/src/XLParser.Tests/XLParser.Tests.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Irony" Version="1.2.0" />
+    <PackageReference Include="Irony" Version="1.5.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />

--- a/src/XLParser/XLParser.csproj
+++ b/src/XLParser/XLParser.csproj
@@ -32,6 +32,6 @@
     <EmbeddedResource Include="Resources\ExcelBuiltinFunctionList.txt" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Irony" Version="1.2.0" />
+    <PackageReference Include="Irony" Version="1.5.3" />
   </ItemGroup>
 </Project>

--- a/src/XLParser/XLParser.csproj
+++ b/src/XLParser/XLParser.csproj
@@ -22,12 +22,6 @@
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net462'">
-    <DefineConstants>$(DefineConstants);_NET462_</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <DefineConstants>$(DefineConstants);_NETSTANDARD_</DefineConstants>
-  </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\ExcelBuiltinFunctionList.txt" />
   </ItemGroup>


### PR DESCRIPTION
- Update packages of XLParser and XLParser.Tests to latest version
- Remove constants from `.csproj` files and code (not really used, and there are [built-in preprocessor symbols](https://learn.microsoft.com/en-us/dotnet/standard/frameworks#preprocessor-symbols))
- Upgrade target framework of XLParser.Tests to `net8.0`