### PR TITLE
fixed being unable to parse .xls extensions and added test

### DIFF
--- a/src/XLParser.Tests/FormulaAnalysisTest.cs
+++ b/src/XLParser.Tests/FormulaAnalysisTest.cs
@@ -1002,6 +1002,15 @@ namespace XLParser.Tests
             Assert.AreEqual("Articles.xlsx", references[0].FileName);
         }
 
+        [TestMethod]
+        public void ExternalWorkbookWithXlsExtension()
+        {
+            List<ParserReference> references = new FormulaAnalyzer(@"C:\path\test.xls!name").ParserReferences().ToList();
+            Assert.AreEqual(1, references.Count);
+
+            Assert.AreEqual(ReferenceType.UserDefinedName, references[0].ReferenceType);
+            Assert.AreEqual("test.xls", references[0].FileName);
+        }
 
         [TestMethod]
         public void ExternalWorkbookQuotesInPath()

--- a/src/XLParser/ExcelFormulaGrammar.cs
+++ b/src/XLParser/ExcelFormulaGrammar.cs
@@ -199,7 +199,7 @@ namespace XLParser
         { Priority = TerminalPriority.FileName };
 
         // Source: https://stackoverflow.com/a/14632579
-        private const string fileNameRegex = @"[^\.\\\[\]]+\..{1,4}";
+        private const string fileNameRegex = @"[^\.\\\[\]]+\.[a-zA-z]{1,4}";
         public Terminal FileName { get; } = new RegexBasedTerminal(GrammarNames.TokenFileName, fileNameRegex)
         { Priority = TerminalPriority.FileName };
 


### PR DESCRIPTION
Closes #197 . This change does mean any files with non alphabetical file extensions are not supported. However almost all imported files should be an excel extension.