### PR TITLE
Fix preceding space in SR column name

### DIFF
--- a/src/XLParser.Tests/FormulaAnalysisTest.cs
+++ b/src/XLParser.Tests/FormulaAnalysisTest.cs
@@ -522,6 +522,19 @@ namespace XLParser.Tests
         }
 
         [TestMethod]
+        public void StructuredTableReferenceWithLeadingAndTrailingSpace()
+        {
+            // See https://github.com/spreadsheetlab/XLParser/issues/209
+            List<ParserReference> references = new FormulaAnalyzer("=Table1[ Column ]").ParserReferences().ToList();
+
+            Assert.AreEqual(1, references.Count);
+
+            Assert.AreEqual(ReferenceType.Table, references[0].ReferenceType);
+            Assert.AreEqual("Table1", references[0].Name);
+            CollectionAssert.AreEqual(new[] { "Column" }, references[0].TableColumns);
+        }
+
+        [TestMethod]
         public void SheetWithUnderscore()
         {
             ParseTree parseResult = ExcelFormulaParser.ParseToTree("aap_noot!B12");

--- a/src/XLParser.Tests/FormulaAnalysisTest.cs
+++ b/src/XLParser.Tests/FormulaAnalysisTest.cs
@@ -535,6 +535,32 @@ namespace XLParser.Tests
         }
 
         [TestMethod]
+        public void StructuredTableReferenceWithTrailingSpaces()
+        {
+            // See https://github.com/spreadsheetlab/XLParser/issues/209
+            List<ParserReference> references = new FormulaAnalyzer("=Table1[Column   ]").ParserReferences().ToList();
+
+            Assert.AreEqual(1, references.Count);
+
+            Assert.AreEqual(ReferenceType.Table, references[0].ReferenceType);
+            Assert.AreEqual("Table1", references[0].Name);
+            CollectionAssert.AreEqual(new[] { "Column   " }, references[0].TableColumns);
+        }
+
+        [TestMethod]
+        public void StructuredTableReferenceWithPrecedingAndTrailingSpaces()
+        {
+            // See https://github.com/spreadsheetlab/XLParser/issues/209
+            List<ParserReference> references = new FormulaAnalyzer("=Table1[  Column   ]").ParserReferences().ToList();
+
+            Assert.AreEqual(1, references.Count);
+
+            Assert.AreEqual(ReferenceType.Table, references[0].ReferenceType);
+            Assert.AreEqual("Table1", references[0].Name);
+            CollectionAssert.AreEqual(new[] { "  Column   " }, references[0].TableColumns);
+        }
+
+        [TestMethod]
         public void SheetWithUnderscore()
         {
             ParseTree parseResult = ExcelFormulaParser.ParseToTree("aap_noot!B12");

--- a/src/XLParser.Tests/FormulaAnalysisTest.cs
+++ b/src/XLParser.Tests/FormulaAnalysisTest.cs
@@ -522,16 +522,16 @@ namespace XLParser.Tests
         }
 
         [TestMethod]
-        public void StructuredTableReferenceWithLeadingAndTrailingSpace()
+        public void StructuredTableReferenceWithPrecedingSpace()
         {
             // See https://github.com/spreadsheetlab/XLParser/issues/209
-            List<ParserReference> references = new FormulaAnalyzer("=Table1[ Column ]").ParserReferences().ToList();
+            List<ParserReference> references = new FormulaAnalyzer("=Table1[ Column]").ParserReferences().ToList();
 
             Assert.AreEqual(1, references.Count);
 
             Assert.AreEqual(ReferenceType.Table, references[0].ReferenceType);
             Assert.AreEqual("Table1", references[0].Name);
-            CollectionAssert.AreEqual(new[] { " Column " }, references[0].TableColumns);
+            CollectionAssert.AreEqual(new[] { " Column" }, references[0].TableColumns);
         }
 
         [TestMethod]

--- a/src/XLParser.Tests/FormulaAnalysisTest.cs
+++ b/src/XLParser.Tests/FormulaAnalysisTest.cs
@@ -531,7 +531,7 @@ namespace XLParser.Tests
 
             Assert.AreEqual(ReferenceType.Table, references[0].ReferenceType);
             Assert.AreEqual("Table1", references[0].Name);
-            CollectionAssert.AreEqual(new[] { "Column" }, references[0].TableColumns);
+            CollectionAssert.AreEqual(new[] { " Column " }, references[0].TableColumns);
         }
 
         [TestMethod]

--- a/src/XLParser/ExcelFormulaParser.cs
+++ b/src/XLParser/ExcelFormulaParser.cs
@@ -59,11 +59,12 @@ namespace XLParser
                 intersect.Span = new SourceSpan(newLocation, 1);
             }
 
-            var quotedSheetNodes = tree.Root.AllNodes().Where(node => node.Is(GrammarNames.TokenSheetQuoted));
+            //Quoted sheets and SR Columns require the preceding whitespaces skipped by Irony as they are needed for unique sheet and column names
+            var precedingWhiteSpaceNodes = tree.Root.AllNodes().Where(node => node.Is(GrammarNames.TokenSheetQuoted) | node.Is(GrammarNames.TokenSRColumn));
 
-            foreach (ParseTreeNode quotedSheetNode in quotedSheetNodes)
+            foreach (ParseTreeNode precedingWhiteSpaceNode in precedingWhiteSpaceNodes)
             {
-                PrefixInfo.FixQuotedSheetNodeForWhitespace(quotedSheetNode, input);
+                PrefixInfo.FixPrecedingWhiteSpaces(precedingWhiteSpaceNode, input);
             }
 
             return tree;

--- a/src/XLParser/ParserReference.cs
+++ b/src/XLParser/ParserReference.cs
@@ -75,27 +75,27 @@ namespace XLParser
                     break;
                 case GrammarNames.Cell:
                     ReferenceType = ReferenceType.Cell;
-                    MinLocation = node.ChildNodes[0].Token.ValueString;
+                    MinLocation = node.ChildNodes[0].Token.Text;
                     MaxLocation = MinLocation;
                     break;
                 case GrammarNames.NamedRange:
                     ReferenceType = ReferenceType.UserDefinedName;
-                    Name = node.ChildNodes[0].Token.ValueString;
+                    Name = node.ChildNodes[0].Token.Text;
                     break;
                 case GrammarNames.StructuredReference:
                     ReferenceType = ReferenceType.Table;
-                    Name = node.ChildNodes.FirstOrDefault(x => x.Type() == GrammarNames.StructuredReferenceQualifier)?.ChildNodes[0].Token.ValueString;
-                    TableSpecifiers = node.AllNodes().Where(x => x.Is(GrammarNames.TokenSRSpecifier) || x.Is("@")).Select(x => UnEscape(x.Token.ValueString, "'")).ToArray();
-                    TableColumns = node.AllNodes().Where(x => x.Is(GrammarNames.TokenSRColumn)).Select(x => UnEscape(x.Token.ValueString, "'")).ToArray();
+                    Name = node.ChildNodes.FirstOrDefault(x => x.Type() == GrammarNames.StructuredReferenceQualifier)?.ChildNodes[0].Token.Text;
+                    TableSpecifiers = node.AllNodes().Where(x => x.Is(GrammarNames.TokenSRSpecifier) || x.Is("@")).Select(x => UnEscape(x.Token.Text, "'")).ToArray();
+                    TableColumns = node.AllNodes().Where(x => x.Is(GrammarNames.TokenSRColumn)).Select(x => UnEscape(x.Token.Text, "'")).ToArray();
                     break;
                 case GrammarNames.HorizontalRange:
-                    string[] horizontalLimits = node.ChildNodes[0].Token.ValueString.Split(':');
+                    string[] horizontalLimits = node.ChildNodes[0].Token.Text.Split(':');
                     ReferenceType = ReferenceType.HorizontalRange;
                     MinLocation = horizontalLimits[0];
                     MaxLocation = horizontalLimits[1];
                     break;
                 case GrammarNames.VerticalRange:
-                    string[] verticalLimits = node.ChildNodes[0].Token.ValueString.Split(':');
+                    string[] verticalLimits = node.ChildNodes[0].Token.Text.Split(':');
                     ReferenceType = ReferenceType.VerticalRange;
                     MinLocation = verticalLimits[0];
                     MaxLocation = verticalLimits[1];
@@ -105,7 +105,7 @@ namespace XLParser
                     break;
                 case GrammarNames.UDFunctionCall:
                     ReferenceType = ReferenceType.UserDefinedFunction;
-                    Name = node.ChildNodes[0].ChildNodes[0].Token.ValueString.TrimEnd('(');
+                    Name = node.ChildNodes[0].ChildNodes[0].Token.Text.TrimEnd('(');
                     break;
             }
 

--- a/src/XLParser/PrefixInfo.cs
+++ b/src/XLParser/PrefixInfo.cs
@@ -130,24 +130,24 @@ namespace XLParser
             return new PrefixInfo(sheetName, fileNumber, fileName, filePath, multipleSheets, isQuoted);
         }
 
-        internal static void FixQuotedSheetNodeForWhitespace(ParseTreeNode quotedSheetNode, string sourceText)
+        internal static void FixPrecedingWhiteSpaces(ParseTreeNode parseTreeNode, string sourceText)
         {
-            var newPosition = GetSheetNamePositionFromSourceText(quotedSheetNode, sourceText);
-            SourceLocation currentLocation = quotedSheetNode.Span.Location;
+            var newPosition = GetNodePositionFromSourceText(parseTreeNode, sourceText);
+            SourceLocation currentLocation = parseTreeNode.Span.Location;
             if (newPosition == currentLocation.Position)
             {
                 return;
             }
 
             var newLocation = new SourceLocation(newPosition, currentLocation.Line, currentLocation.Column + currentLocation.Position - newPosition);
-            quotedSheetNode.Span = new SourceSpan(newLocation, quotedSheetNode.Span.EndPosition - newPosition);
+            parseTreeNode.Span = new SourceSpan(newLocation, parseTreeNode.Span.EndPosition - newPosition);
 
-            // Cannot directly assign to quotedSheetNode.Token.Text; it is read-only. Falling back on reflection.
+            // Cannot directly assign to parseTreeNode.Token.Text; it is read-only. Falling back on reflection.
             typeof(Token).GetField("Text", BindingFlags.Instance | BindingFlags.Public)
-                ?.SetValue(quotedSheetNode.Token, sourceText.Substring(newPosition, quotedSheetNode.Span.Length));
+                ?.SetValue(parseTreeNode.Token, sourceText.Substring(newPosition, parseTreeNode.Span.Length));
         }
 
-        private static int GetSheetNamePositionFromSourceText(ParseTreeNode nodeSheetQuoted, string sourceText)
+        private static int GetNodePositionFromSourceText(ParseTreeNode nodeSheetQuoted, string sourceText)
         {
             var startIndex = nodeSheetQuoted.Span.Location.Position;
 


### PR DESCRIPTION
Closes #209 
This fix reuses the code for quoted sheet names to include preceding spaces in the column name.

First of all I renamed the function FixQuotedSheetNodeForWhitespace to FixPrecedingWhiteSpaces and adjusted the names in the function to be general to any node. 

Secondly in the ExcelFormulaParser class I then included SRColumn tokens in the list of nodes that the function is called on.

Finally in the ParserReference file I replaced the usages of ValueString with Text. This allows the ColumnNames property to also work with the previous FixPrecedingWhiteSpaces function. This was the only place we used the ValueString property and replacing it caused no unit tests to fail. The main difference between the two seems to be that ValueString excludes quotes in TextTokens so it makes no difference here.

It is hard to find documentation on this though so it is possible ValueString was used for a reason here but I don't see it.