### PR TITLE
SR without table name confused for filename in brackets

### DIFF
--- a/src/XLParser.Tests/ParserTests.cs
+++ b/src/XLParser.Tests/ParserTests.cs
@@ -629,7 +629,11 @@ namespace XLParser.Tests
         [TestMethod]
         public void TableReferenceWithSheetReference()
         {
+            //See [#198] (https://github.com/spreadsheetlab/XLParser/issues/198)
             Test("=SUM([Column1],' Sheet1'!A1)");
+            Test("[Column1] + Sheet1!A1");
+            Test("=SUM([Column1],' Sheet1:Sheet2'!A1)");
+            Test("=[Column1] + Sheet1:Sheet2!A1");
         }
 
         [TestMethod]

--- a/src/XLParser.Tests/ParserTests.cs
+++ b/src/XLParser.Tests/ParserTests.cs
@@ -629,7 +629,7 @@ namespace XLParser.Tests
         [TestMethod]
         public void TableReferenceWithSheetReference()
         {
-            Test("=[row1]*Sheet1!A1");
+            Test("=SUM([Column1],' Sheet1'!A1)");
         }
 
         [TestMethod]

--- a/src/XLParser/ExcelFormulaGrammar.cs
+++ b/src/XLParser/ExcelFormulaGrammar.cs
@@ -194,7 +194,7 @@ namespace XLParser
         public Terminal FileNameNumericToken = new RegexBasedTerminal(GrammarNames.TokenFileNameNumeric, fileNameNumericRegex, "[")
         { Priority = TerminalPriority.FileNameNumericToken };
 
-        private static readonly string fileNameInBracketsRegex = @"\[[^\[\]]+\]" + $"(?={normalSheetName}|{quotedSheetName}'|!)";
+        private static readonly string fileNameInBracketsRegex = @"\[[^\[\]]+\]" + $"(?={normalSheetName}!|{quotedSheetName}'!|{multiSheetRegex}|{multiSheetQuotedRegex}|!)";
         public Terminal FileNameEnclosedInBracketsToken { get; } = new RegexBasedTerminal(GrammarNames.TokenFileNameEnclosedInBrackets, fileNameInBracketsRegex, "[")
         { Priority = TerminalPriority.FileName };
 


### PR DESCRIPTION
Closes #198  

Made the Regex lookahead even stricter. I looked at the duration of the tests in the test explorer and it seems to have no significant impact on the run time.

It would be much nicer to do this inside the grammar rather than as a lookahead behind a regex, however that would require the grammar to only reduce if it can reduce the entire rule for a prefix which is not possible from what I can see.